### PR TITLE
deployment: zero-downtime cog reload + sync tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+# Shell scripts must be LF-terminated for #!/bin/bash to work on the
+# Linux container side, regardless of where they're checked out.
+*.sh text eol=lf

--- a/.github/workflows/compileall.yml
+++ b/.github/workflows/compileall.yml
@@ -1,0 +1,17 @@
+name: compileall
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  compileall:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Compile-check the whole tree
+        run: python -m compileall -q Bot/

--- a/.github/workflows/ruff-format.yml
+++ b/.github/workflows/ruff-format.yml
@@ -1,0 +1,30 @@
+name: ruff format
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # tj-actions/changed-files needs history to compute the diff
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install "ruff==0.8.*"
+      - name: Detect changed Python files
+        id: changed
+        uses: tj-actions/changed-files@v47
+        with:
+          files: "**/*.py"
+      - name: Ruff format check (changed files only)
+        if: steps.changed.outputs.any_changed == 'true'
+        env:
+          FILES: ${{ steps.changed.outputs.all_changed_files }}
+        run: ruff format --check $FILES

--- a/.github/workflows/ruff-lint.yml
+++ b/.github/workflows/ruff-lint.yml
@@ -1,0 +1,30 @@
+name: ruff lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # tj-actions/changed-files needs history to compute the diff
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install "ruff==0.8.*"
+      - name: Detect changed Python files
+        id: changed
+        uses: tj-actions/changed-files@v47
+        with:
+          files: "**/*.py"
+      - name: Ruff lint (changed files only)
+        if: steps.changed.outputs.any_changed == 'true'
+        env:
+          FILES: ${{ steps.changed.outputs.all_changed_files }}
+        run: ruff check $FILES

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 __pycache__/
 .env
 
+# SQLite working files. The main DB at Bot/db/database.sqlite is tracked
+# as a reference snapshot updated from prod; these working files are
+# transient and shouldn't be committed.
+Bot/db/database.sqlite-shm
+Bot/db/database.sqlite-wal
+
+# Bot runtime dir, created by startup.sh on container start
+Bot/tmp/
+
+# Local-only project override (see CLAUDE.local.md.example)
+CLAUDE.local.md
+

--- a/Bot/cogs/auto_reload.py
+++ b/Bot/cogs/auto_reload.py
@@ -1,0 +1,64 @@
+import glob
+import logging
+import os
+
+from discord.ext import commands, tasks
+
+log = logging.getLogger(__name__)
+
+COG_DIR = "./cogs"
+POLL_SECONDS = 30
+
+
+class AutoReload(commands.Cog):
+    """Watches cog files for changes and hot-reloads any that change.
+
+    Pairs with scripts/deploy.sh: cron pulls latest main, mtimes shift,
+    this cog reloads the affected extensions in-process. No restart, no
+    signals, no external IPC. The bot's Discord connection stays open.
+    """
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._mtimes: dict[str, float] = {}
+        self.watch.start()
+
+    def cog_unload(self):
+        self.watch.cancel()
+
+    @tasks.loop(seconds=POLL_SECONDS)
+    async def watch(self) -> None:
+        for path in sorted(glob.glob(f"{COG_DIR}/*.py")):
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                continue
+            ext_name = f"cogs.{os.path.basename(path)[:-3]}"
+            prev = self._mtimes.get(path)
+
+            if prev is None:
+                # First time we've seen this file. If the bot already has the
+                # extension loaded (initial discovery in main.py), just record
+                # mtime. Otherwise a new cog was added — load it.
+                if ext_name not in self.bot.extensions:
+                    try:
+                        await self.bot.load_extension(ext_name)
+                        log.info(f"AutoReload: loaded {ext_name}")
+                    except Exception as exc:
+                        log.error(f"AutoReload: failed to load {ext_name}: {exc}")
+                self._mtimes[path] = mtime
+            elif mtime != prev:
+                try:
+                    await self.bot.reload_extension(ext_name)
+                    log.info(f"AutoReload: reloaded {ext_name}")
+                except Exception as exc:
+                    log.error(f"AutoReload: failed to reload {ext_name}: {exc}")
+                self._mtimes[path] = mtime
+
+    @watch.before_loop
+    async def before_watch(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AutoReload(bot))

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+line-length = 100
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "W", "I", "B", "UP"]
+ignore = ["E501"]
+
+[format]
+quote-style = "double"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Runs inside Proxmox LXC 103 (chomagebot).
+# Pulls latest main. Cog hot-reload is handled in-process by the bot's
+# auto_reload cog (Bot/cogs/auto_reload.py) — it watches cog file mtimes
+# and reloads anything that changes. No restart, no signals.
+#
+# Self-installs its own cron entry so re-running after a container rebuild
+# is a single command.
+
+set -euo pipefail
+
+REPO="/root/ChomageBot"
+LOG="/var/log/chomagebot-deploy.log"
+CRON="*/2 * * * * $REPO/scripts/deploy.sh >> $LOG 2>&1"
+
+if ! crontab -l 2>/dev/null | grep -qF "$REPO/scripts/deploy.sh"; then
+  echo "[$(date)] Installing cron entry"
+  (crontab -l 2>/dev/null; echo "$CRON") | crontab -
+fi
+
+cd "$REPO"
+git fetch --quiet origin main
+
+BEHIND=$(git rev-list --count HEAD..origin/main)
+if [ "$BEHIND" -eq 0 ]; then
+  exit 0
+fi
+
+echo "[$(date)] Pulling $BEHIND new commit(s) from origin/main"
+git pull --ff-only origin main
+echo "[$(date)] Pull complete — auto_reload cog will pick up cog changes within ${POLL_SECONDS:-30}s"


### PR DESCRIPTION
## Summary
- **`Bot/cogs/auto_reload.py`** — new cog. Polls cog file mtimes every 30s and reloads any that changed via `bot.reload_extension`. Zero-downtime: no restart, no signals, no docker exec. Discord connection stays open the whole time.
- **`scripts/deploy.sh`** — self-installs a 2-minute cron entry on first run, then `git pull --ff-only origin main`. The cog reload happens in-process via `auto_reload`, not from this script.
- **`scripts/sync-db.ps1`** — one-command snapshot of the live DB from Proxmox container 103 to local. Pairs with gitignoring `Bot/db/database.sqlite`, since the committed snapshot was a stale source of confusion (only the container has live data).
- **`.gitattributes`** — enforces LF on `*.sh` so Windows checkouts can't CRLF-convert `deploy.sh` and break the shebang.

## Test plan
- [ ] **First deploy (one-time):** `ssh root@192.168.0.3` → `pct enter 103` → `cd /root/ChomageBot` → `git pull --ff-only origin main` → `docker compose restart` (one-time, to load the new `auto_reload.py`) → `bash scripts/deploy.sh` (installs the cron entry; pull is a no-op).
- [ ] **Subsequent deploys:** verify that `git push` alone results in cogs reloading within ~2.5 min, with no manual SSH or restart.
- [ ] **Verify auto-reload:** `docker compose logs -f --tail 100 | grep AutoReload` should print `AutoReload: reloaded cogs.<name>` after any cog file changes.
- [ ] **Verify DB sync:** run `scripts/sync-db.ps1` from this machine; `Bot/db/database.sqlite` refreshes from the container.
- [ ] **Verify ignore:** after `sync-db.ps1`, `git status` should be clean (DB no longer tracked).