### PR TITLE
fix: graphing now reaches both legacy- and puuid-keyed history rows

### DIFF
--- a/Bot/cogs/ranked_graphing.py
+++ b/Bot/cogs/ranked_graphing.py
@@ -56,9 +56,17 @@ class LeagueGraphs(commands.Cog):
 
             # plt._backend_mod.new_figure_manager_given_figure(1, fig)
         async with sqa.connect(self.bot.db_path) as connection:
+            # Older history rows are keyed by the legacy 47-char summoner ID
+            # (league_players.leagueId), newer rows by the real 78-char puuid.
+            # Match on either via a UNION subquery so legacy-tracked players
+            # (e.g. DARWIN DARWIN N) actually see their post-migration games.
             async with connection.execute(
-                "SELECT * FROM league_history WHERE timestamp > ? AND puuid = ?",
-                (CURRENT_SPLIT_START, summonerid[0][0]),
+                "SELECT * FROM league_history WHERE timestamp > ? AND puuid IN ("
+                "    SELECT leagueId FROM league_players WHERE league_username = ?"
+                "    UNION"
+                "    SELECT puuid FROM league_players WHERE league_username = ?"
+                ") ORDER BY timestamp ASC",
+                (CURRENT_SPLIT_START, league_name, league_name),
             ) as cursor:
                 x_to_plot = []
                 y_to_plot = []
@@ -131,9 +139,15 @@ class LeagueGraphs(commands.Cog):
 
         # plt._backend_mod.new_figure_manager_given_figure(1, fig)
         async with sqa.connect(self.bot.db_path) as connection:
+            # See generate_singular: match both legacy leagueId and modern
+            # puuid via UNION so legacy-tracked players surface correctly.
             async with connection.execute(
-                "SELECT * FROM league_history WHERE timestamp > ? AND puuid = ?",
-                (CURRENT_SPLIT_START, summonerid[0][0]),
+                "SELECT * FROM league_history WHERE timestamp > ? AND puuid IN ("
+                "    SELECT leagueId FROM league_players WHERE league_username = ?"
+                "    UNION"
+                "    SELECT puuid FROM league_players WHERE league_username = ?"
+                ") ORDER BY timestamp ASC",
+                (CURRENT_SPLIT_START, league_name, league_name),
             ) as cursor:
                 score_dict = {}
                 async for point in cursor:


### PR DESCRIPTION
/graph_user_granular and /graph_user_average looked up leagueId from league_players and then queried league_history.puuid = leagueId. That works for modern entries where leagueId == puuid (both 78-char real puuids) but silently returns zero rows for legacy entries — DARWIN DARWIN N has 209 valid 2026 rows keyed by their 78-char puuid, but the query was using their 47-char legacy summoner ID.

Same fix pattern as get_last_five_games in league_table_updater
(commit bbb8082, 2026-05-17): replace the WHERE puuid = <single>
with WHERE puuid IN (<UNION of both ID forms from league_players>). The standalone leagueId-from-name lookup is now folded into the data query, and we order by timestamp ASC so plotting is in chronological order.

Verified on prod: DARWIN's query now returns 209 rows vs the prior 0.