### PR TITLE
fix: drop the long backfill write transaction + persist WAL in setup.sql

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -247,18 +247,28 @@ class Backfill(commands.Cog):
         return inserted_total
 
     async def _insert_matches(self, puuid: str, match_ids: list[str]) -> int:
+        """Fetch + insert match details one at a time, opening a fresh
+        connection per write.
+
+        Why per-match: bundling the whole page under one transaction
+        held the writer lock across N network calls (~50-500ms each),
+        which starved /refresh_ranks and other writers and tripped the
+        5-second busy_timeout. Opening a new connection only around the
+        insert holds the lock for milliseconds — other writers can
+        interleave freely under WAL.
+        """
         inserted = 0
-        async with sqa.connect(self.bot.db_path) as db:
-            for mid in match_ids:
-                match = await get_match(mid)
-                if match is None:
+        for mid in match_ids:
+            match = await get_match(mid)
+            if match is None:
+                continue
+            for participant in match["info"]["participants"]:
+                if participant["puuid"] != puuid:
                     continue
-                for participant in match["info"]["participants"]:
-                    if participant["puuid"] != puuid:
-                        continue
-                    game_start = dt.datetime.fromtimestamp(
-                        match["info"]["gameStartTimestamp"] / 1000.0
-                    ).strftime("%Y-%m-%d %H:%M:%S")
+                game_start = dt.datetime.fromtimestamp(
+                    match["info"]["gameStartTimestamp"] / 1000.0
+                ).strftime("%Y-%m-%d %H:%M:%S")
+                async with sqa.connect(self.bot.db_path) as db:
                     await db.execute(
                         "INSERT OR IGNORE INTO match_stats "
                         "(match_id, puuid, game_start, queue_id, champion, "
@@ -277,9 +287,9 @@ class Backfill(commands.Cog):
                             match["info"]["gameDuration"],
                         ),
                     )
-                    inserted += 1
-                    break
-            await db.commit()
+                    await db.commit()
+                inserted += 1
+                break
         return inserted
 
 

--- a/Bot/db/setup.sql
+++ b/Bot/db/setup.sql
@@ -1,3 +1,9 @@
+-- Persist journal mode = WAL on this DB. Avoids "database is locked"
+-- contention between concurrent writers (e.g. backfill writing match_stats
+-- while post_ranks writes league_history). Persistent in the file once set;
+-- this line keeps fresh DBs (from a clean container build) on WAL too.
+pragma journal_mode = wal;
+
 create table if not exists discord_channels (
     channel_id INTEGER not null primary key,
     name TEXT not null,


### PR DESCRIPTION
Two related contention fixes for "database is locked" on /refresh_ranks and other writers while a backfill is running.

Root cause: _insert_matches opened a single connection at the top of its loop, ran INSERTs against it across N network calls (~50-500ms each via get_match), then committed at the end. After the first INSERT the connection held the RESERVED writer lock continuously through the rest of the network calls — locking out every other writer for up to a few minutes per page. Default busy_timeout is 5s, hence the OperationalError on refresh_ranks under load.

Fix #1: open a fresh connection only around the actual INSERT, after the network fetch has returned. Lock held milliseconds per match instead of minutes per page. Other writers (post_ranks, /refresh_ranks update_table) can interleave between matches.

Fix #2: `pragma journal_mode = wal;` at the top of setup.sql so fresh DBs (from container rebuilds) start in WAL mode. The live DB has already been migrated to WAL by hand via `PRAGMA journal_mode=WAL;` this morning, so this is for posterity.

Combined with WAL, multiple writers coexist with sub-second waits and no busy_timeout violations.