### PR TITLE
Diagnostic: list_guild_roles.py

### DIFF
--- a/Bot/cogs/match_analysis.py
+++ b/Bot/cogs/match_analysis.py
@@ -95,6 +95,21 @@ PANEL_SELECT_ID = f"{PANEL_CUSTOM_ID_PREFIX}:person"
 # ``_build_panel_embed``.
 PANEL_EMBED_TITLE = "📊 ChomageBot — Match Stats"
 
+# Role name (case-sensitive) gating the admin slash commands. We use a
+# role check rather than ``default_permissions`` because the friend
+# group's admins don't have the built-in ``manage_guild`` perm — Discord
+# would hide the commands from them.
+CHOMAGE_KEEPER_ROLE = "Keeper of Chomage"
+
+
+def _is_chomage_keeper(interaction: discord.Interaction) -> bool:
+    """app_commands.check predicate: True iff invoker has the keeper role."""
+    user = interaction.user
+    if not isinstance(user, discord.Member):
+        return False
+    return any(role.name == CHOMAGE_KEEPER_ROLE for role in user.roles)
+
+
 # How often the sticky-pin loop checks whether the panel is still the
 # most-recent message in PANEL_CHANNEL_ID. Cheap (one history call),
 # generous enough to avoid API noise.
@@ -1182,12 +1197,34 @@ class MatchAnalysis(commands.Cog):
         self.sticky_panel.cancel()
         self._panel_view.stop()
 
+    async def cog_app_command_error(
+        self,
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        """Make `@app_commands.check` failures user-visible.
+
+        Without this, denied admin invocations surface as a generic
+        "interaction failed" — confusing for non-keepers who didn't know
+        the command existed.
+        """
+        if isinstance(error, app_commands.CheckFailure):
+            msg = f"That command is restricted to the **{CHOMAGE_KEEPER_ROLE}** role."
+            if interaction.response.is_done():
+                await interaction.followup.send(msg, ephemeral=True)
+            else:
+                await interaction.response.send_message(msg, ephemeral=True)
+            return
+        # Let the rest fall through to default handling (raises into the
+        # bot's global error handler, if any).
+        raise error
+
     @app_commands.command(
         name="match_stats_panel",
         description="(Re-)post the persistent match-stats control panel in the dedicated channel",
     )
     @app_commands.guild_only()
-    @app_commands.default_permissions(manage_channels=True)
+    @app_commands.check(_is_chomage_keeper)
     async def match_stats_panel(self, ctx: discord.Interaction) -> None:
         await ctx.response.defer(ephemeral=True)
 
@@ -1229,7 +1266,7 @@ class MatchAnalysis(commands.Cog):
         description="Clear the 5-minute chart-data cache (admin only)",
     )
     @app_commands.guild_only()
-    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.check(_is_chomage_keeper)
     async def refresh_db_cache(self, interaction: discord.Interaction) -> None:
         """Force the next chart render to re-read match_stats from disk
         instead of using the in-memory cache. Useful after running a backfill
@@ -1245,7 +1282,7 @@ class MatchAnalysis(commands.Cog):
 
     @app_commands.command(name="whois", description="Bot operational status (admin)")
     @app_commands.guild_only()
-    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.check(_is_chomage_keeper)
     async def whois(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
 

--- a/scripts/list_guild_roles.py
+++ b/scripts/list_guild_roles.py
@@ -1,0 +1,77 @@
+"""List every role in the bot's guild(s) — diagnostic helper.
+
+Reads the bot token from the BOT_TOKEN environment variable (or
+DISCORD_TOKEN, matching the bot's own config) and dumps each guild's
+role list to stdout. Useful when an `app_commands.check` is rejecting
+invocations and we need the EXACT role name (case + unicode) the
+guild has.
+
+Usage (from inside container 103, after `source .env` or equivalent):
+    python3 scripts/list_guild_roles.py
+
+Read-only. Does not write to the DB. Does not start the gateway —
+uses Discord's REST API directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://discord.com/api/v10"
+
+
+def _token() -> str:
+    for env_var in ("BOT_TOKEN", "DISCORD_TOKEN", "TOKEN"):
+        tok = os.environ.get(env_var)
+        if tok:
+            return tok
+    sys.exit(
+        "ERROR: no BOT_TOKEN / DISCORD_TOKEN / TOKEN env var. "
+        "Source your .env first: `set -a; source .env; set +a`"
+    )
+
+
+def _request(path: str, token: str) -> object:
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Authorization": f"Bot {token}",
+            "User-Agent": "ChomageBot-RoleLister/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def main() -> int:
+    token = _token()
+    try:
+        guilds = _request("/users/@me/guilds", token)
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: {exc.code} listing guilds: {exc.read().decode('utf-8')[:200]}")
+        return 1
+
+    print(f"Bot is in {len(guilds)} guild(s):\n")
+    for g in guilds:
+        gid, gname = g["id"], g["name"]
+        print(f"=== {gname}  (id={gid}) ===")
+        try:
+            roles = _request(f"/guilds/{gid}/roles", token)
+        except urllib.error.HTTPError as exc:
+            print(f"  ERROR fetching roles: {exc.code} {exc.read().decode('utf-8')[:200]}")
+            continue
+        # Sort by position descending (highest = listed first in Discord UI).
+        roles.sort(key=lambda r: r["position"], reverse=True)
+        for r in roles:
+            # `repr` exposes unicode quirks (curly quotes, NBSP, em-dash, ZWSP).
+            print(f"  {repr(r['name']):<40}  (id={r['id']})")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
One-off helper to print every role in each guild the bot is in, so we can verify the exact spelling (case + unicode) of the `Keeper of Chomage` role that's currently failing the `/whois` role check.

Read-only, no DB writes. Uses Discord's REST API directly (no gateway connection). Reads token from `BOT_TOKEN`/`DISCORD_TOKEN`/`TOKEN` env var.

**Usage on prod:**
```bash
ssh root@192.168.0.3 "pct exec 103 -- bash -c 'cd /root/ChomageBot && set -a && source .env && set +a && python3 scripts/list_guild_roles.py'"
```

Output uses `repr()` on role names so curly quotes / NBSP / em-dashes / ZWSP show up explicitly.
