### PR TITLE
C:/Program Files/Git/refresh sync — guild-scope first for instant visibility

### DIFF
--- a/Bot/cogs/sync.py
+++ b/Bot/cogs/sync.py
@@ -20,20 +20,36 @@ class Refresh(
 
     @command(name="sync")
     async def sync(self, ctx: discord.Interaction):
-        """Command to sync all slash commands to discord
+        """Sync slash commands.
 
-        Args:
-            ctx (discord.Interaction): The discord interaction object
+        Guild-scope sync first (instant — appears immediately in this
+        server) followed by a global sync (canonical, propagates to
+        other servers / DMs over the next ~hour). Mirrors the pattern
+        in ``Bot/utils/sync_commands.py`` so admins don't have to wait
+        for global propagation after updating a command's decorator.
         """
         await ctx.response.defer()
         msg = await ctx.followup.send("Syncing commands...", wait=True, ephemeral=True)
         self.bot.logging.info("Syncing commands")
         try:
-            await self.bot.tree.sync()
-            await msg.edit(content="Succesfully synced")
+            guild = ctx.guild
+            if guild is not None:
+                self.bot.tree.copy_global_to(guild=guild)
+                guild_synced = await self.bot.tree.sync(guild=guild)
+                self.bot.logging.info(
+                    f"Synced {len(guild_synced)} guild-scope command(s) to {guild.id}"
+                )
+            global_synced = await self.bot.tree.sync()
+            self.bot.logging.info(f"Synced {len(global_synced)} global command(s)")
+            await msg.edit(
+                content=(
+                    f"Synced {len(guild_synced) if guild else 0} guild + "
+                    f"{len(global_synced)} global commands."
+                )
+            )
         except Exception as e:
             self.bot.logging.error(f"Failed to sync due to: {e}")
-            await msg.edit(content="Unsuccesful sync")
+            await msg.edit(content=f"Unsuccessful sync: {e!r}")
 
     @command(name="reload_cogs")
     async def reload_cogs(self, ctx: discord.Interaction):


### PR DESCRIPTION
**Why `/whois` and other recently-added commands haven't appeared.**

`/refresh sync` was calling `bot.tree.sync()` with no `guild=` arg — that's a **global** sync, which can take **up to one hour** to propagate through Discord's CDN. So even after `/refresh sync` succeeds, new/changed commands may stay hidden in your client for ages.

**Fix:** mirror the pattern already in `Bot/utils/sync_commands.py` (the standalone bootstrap script):
1. `tree.copy_global_to(guild=ctx.guild)` — copies the globally-registered commands into the current guild's tree
2. `tree.sync(guild=ctx.guild)` — instant per-guild sync
3. `tree.sync()` — follow-up global sync (canonical, propagates to other servers / DMs over time)

Confirmation message now reports both counts (`Synced N guild + M global commands.`).

After this lands + prod cron pulls + you run `/refresh sync` once more, `/whois`, `/me_todo`, `/streak`, `/compare`, `/champ`, `/leaderboard_week`, and `/me_text` should appear in your slash menu within seconds.
