### PR TITLE
Command usage tracking + /usage_stats admin command

### DIFF
--- a/Bot/cogs/usage_logger.py
+++ b/Bot/cogs/usage_logger.py
@@ -35,14 +35,16 @@ def _is_chomage_keeper(interaction: discord.Interaction) -> bool:
 
 
 def _name_from_interaction(interaction: discord.Interaction) -> str | None:
-    """Derive a human-readable command identifier from any interaction.
+    """Derive a stable identifier from any interaction.
 
     Returns:
       - For application commands: the full command path, e.g.
         ``/me``, ``/refresh sync``, ``/champ``.
-      - For button clicks: the custom_id, e.g. ``ms:panel:c0``.
-      - For select menus: the custom_id (the chosen value isn't stored
-        — we want command-usage not pick-distribution).
+      - For button clicks: the ``custom_id``, e.g. ``ms:panel:c0``.
+        Decoded to a human chart name at query time in ``/usage_stats``.
+      - For string-select picks: ``<custom_id>=<selected_value>``. The
+        suffix is critical for the More-menu select, where one custom_id
+        would otherwise collapse all chart picks into a single row.
       - None for autocomplete / modal-submit / other low-signal types.
     """
     itype = interaction.type
@@ -65,7 +67,16 @@ def _name_from_interaction(interaction: discord.Interaction) -> str | None:
         return f"/{name.strip()}" if name else None
 
     if itype is discord.InteractionType.component:
-        return data.get("custom_id")
+        custom_id = data.get("custom_id", "")
+        # component_type 2 = button, 3 = string select, 5-8 = other selects.
+        # For selects, suffix the picked value so each pick is its own row
+        # in /usage_stats (without this, the More-menu dropdown's single
+        # custom_id swallows every chart pick into one undifferentiated row).
+        component_type = data.get("component_type")
+        values = data.get("values") or []
+        if component_type in (3, 5, 6, 7, 8) and values:
+            return f"{custom_id}={values[0]}"
+        return custom_id or None
 
     # Skip autocomplete + modal_submit + ping — low value to log.
     return None
@@ -151,8 +162,12 @@ class UsageLogger(commands.Cog):
             )
             return
 
+        # Translate opaque custom_ids into human chart names. Lookups are
+        # done lazily at query time so this cog has no import-time
+        # dependency on cogs.match_analysis (which keeps load order safe).
+        decoder = self._build_decoder()
         lines = [
-            f"`{i + 1:>2}. {name:<28} {n:>4}  ({uniq} unique)`"
+            f"`{i + 1:>2}. {decoder(name):<32} {n:>4}  ({uniq} unique)`"
             for i, (name, n, uniq) in enumerate(rows)
         ]
         embed = discord.Embed(
@@ -161,6 +176,45 @@ class UsageLogger(commands.Cog):
         )
         embed.set_footer(text=f"{total:,} total events · cutoff {cutoff}")
         await interaction.followup.send(embed=embed, ephemeral=True)
+
+    def _build_decoder(self):
+        """Map opaque interaction identifiers to human chart names.
+
+        Looks up the match-analysis cog at query time (not import time)
+        so we don't create a load-order coupling. If the cog isn't
+        loaded, falls back to raw identifiers.
+        """
+        panel_labels: dict[str, str] = {}
+        select_labels: dict[str, str] = {}
+        try:
+            ma_cog = self.bot.get_cog("MatchAnalysis")
+            if ma_cog is not None:
+                from cogs import match_analysis as ma
+
+                # CHART_DEFS is (label, emoji, fn, title) — indexed by cN
+                for idx, entry in enumerate(ma.CHART_DEFS):
+                    label = entry[0]
+                    panel_labels[f"ms:panel:c{idx}"] = f"button: {label}"
+                panel_labels[ma.PANEL_SELECT_ID] = "panel person select"
+
+                # MORE_CHART_DEFS is (stem, label, emoji, description)
+                for entry in ma.MORE_CHART_DEFS:
+                    stem, label = entry[0], entry[1]
+                    select_labels[stem] = f"more: {label}"
+        except Exception:
+            pass
+
+        def decode(name: str) -> str:
+            if name in panel_labels:
+                return panel_labels[name]
+            # Select-pick rows look like "<custom_id>=<value>"
+            if "=" in name:
+                _, value = name.split("=", 1)
+                if value in select_labels:
+                    return select_labels[value]
+            return name
+
+        return decode
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/Bot/cogs/usage_logger.py
+++ b/Bot/cogs/usage_logger.py
@@ -1,0 +1,167 @@
+"""Audit-log slash commands, button clicks, and select-menu picks.
+
+A single cog listens to ``on_interaction`` and writes one row per
+non-autocomplete interaction to the ``command_usage`` table. The
+``/usage_stats`` admin slash command surfaces top commands by window
+so we can later prune the unused ones.
+
+Schema lives in ``Bot/db/setup.sql``; existing DBs migrate via
+``scripts/migrate_add_command_usage.py``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+import aiosqlite as sqa
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+# Match the role-name gate used in cogs.match_analysis for admin commands.
+# Duplicated here (rather than imported) so this cog has no cross-cog
+# import dependencies — keeps load order resilient.
+CHOMAGE_KEEPER_ROLE = "Keeper of Chomage"
+
+log = logging.getLogger(__name__)
+
+
+def _is_chomage_keeper(interaction: discord.Interaction) -> bool:
+    user = interaction.user
+    if not isinstance(user, discord.Member):
+        return False
+    return any(role.name == CHOMAGE_KEEPER_ROLE for role in user.roles)
+
+
+def _name_from_interaction(interaction: discord.Interaction) -> str | None:
+    """Derive a human-readable command identifier from any interaction.
+
+    Returns:
+      - For application commands: the full command path, e.g.
+        ``/me``, ``/refresh sync``, ``/champ``.
+      - For button clicks: the custom_id, e.g. ``ms:panel:c0``.
+      - For select menus: the custom_id (the chosen value isn't stored
+        — we want command-usage not pick-distribution).
+      - None for autocomplete / modal-submit / other low-signal types.
+    """
+    itype = interaction.type
+    data = interaction.data or {}
+
+    if itype is discord.InteractionType.application_command:
+        # Build the full command name including subcommand groups.
+        name = data.get("name", "")
+        # Walk into options for subcommand groups / subcommands.
+        opts = data.get("options", []) or []
+        while opts:
+            first = opts[0]
+            opt_type = first.get("type")
+            # 1 = SUB_COMMAND, 2 = SUB_COMMAND_GROUP
+            if opt_type in (1, 2):
+                name = f"{name} {first.get('name', '')}"
+                opts = first.get("options", []) or []
+            else:
+                break
+        return f"/{name.strip()}" if name else None
+
+    if itype is discord.InteractionType.component:
+        return data.get("custom_id")
+
+    # Skip autocomplete + modal_submit + ping — low value to log.
+    return None
+
+
+class UsageLogger(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.bot.logging.info(f"{__name__} loaded")
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction) -> None:
+        name = _name_from_interaction(interaction)
+        if name is None:
+            return
+        itype = (
+            interaction.type.name if hasattr(interaction.type, "name") else str(interaction.type)
+        )
+        try:
+            async with sqa.connect(self.bot.db_path) as db:
+                await db.execute(
+                    "INSERT INTO command_usage "
+                    "(command_name, user_id, guild_id, interaction_type) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        name,
+                        str(interaction.user.id),
+                        str(interaction.guild_id) if interaction.guild_id else None,
+                        itype,
+                    ),
+                )
+                await db.commit()
+        except Exception as exc:
+            # Never let logging failures break user interactions. The DB
+            # might be locked or the table might not exist yet (pre-
+            # migration). Log + carry on.
+            log.debug(f"usage_logger insert failed for {name!r}: {exc!r}")
+
+    @app_commands.command(
+        name="usage_stats",
+        description="Show top commands / buttons over a window (admin)",
+    )
+    @app_commands.guild_only()
+    @app_commands.check(_is_chomage_keeper)
+    @app_commands.describe(
+        days="Window in days (default 7, max 365)",
+        top="How many entries to show (default 25, max 50)",
+    )
+    async def usage_stats(
+        self,
+        interaction: discord.Interaction,
+        days: int = 7,
+        top: int = 25,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        days = max(1, min(days, 365))
+        top = max(1, min(top, 50))
+
+        cutoff = (dt.datetime.now() - dt.timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            async with sqa.connect(self.bot.db_path) as db:
+                rows = await db.execute_fetchall(
+                    "SELECT command_name, COUNT(*) AS n, "
+                    "COUNT(DISTINCT user_id) AS uniq_users "
+                    "FROM command_usage WHERE timestamp >= ? "
+                    "GROUP BY command_name ORDER BY n DESC LIMIT ?",
+                    (cutoff, top),
+                )
+                total_row = await db.execute_fetchall(
+                    "SELECT COUNT(*) FROM command_usage WHERE timestamp >= ?",
+                    (cutoff,),
+                )
+                total = total_row[0][0] if total_row else 0
+        except Exception as exc:
+            await interaction.followup.send(f"Failed to read usage stats: {exc!r}", ephemeral=True)
+            return
+
+        if not rows:
+            await interaction.followup.send(
+                f"No usage data in the last {days} day(s). "
+                "If the migration just ran, give it time to accumulate.",
+                ephemeral=True,
+            )
+            return
+
+        lines = [
+            f"`{i + 1:>2}. {name:<28} {n:>4}  ({uniq} unique)`"
+            for i, (name, n, uniq) in enumerate(rows)
+        ]
+        embed = discord.Embed(
+            title=f"📊 Usage — last {days}d (top {len(rows)})",
+            description="\n".join(lines),
+        )
+        embed.set_footer(text=f"{total:,} total events · cutoff {cutoff}")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(UsageLogger(bot))

--- a/Bot/db/setup.sql
+++ b/Bot/db/setup.sql
@@ -59,3 +59,17 @@ create table if not exists match_stats (
 create index if not exists idx_match_stats_puuid_time on match_stats (puuid, game_start DESC);
 create unique index if not exists discord_events_event_id_uindex on discord_events (event_id);
 create unique index if not exists users_user_id_uindex on users (user_id);
+-- Audit log of slash commands + button clicks + select-menu picks. Used to
+-- surface which features actually get used, so we can prune the unused ones.
+-- Written by the `usage_logger` cog via the on_interaction event. Indexed
+-- on (timestamp, command_name) for the typical "top commands in last N days"
+-- query.
+create table if not exists command_usage (
+    id INTEGER not null primary key autoincrement,
+    timestamp DATETIME not null DEFAULT CURRENT_TIMESTAMP,
+    command_name TEXT not null,
+    user_id TEXT,
+    guild_id TEXT,
+    interaction_type TEXT not null
+);
+create index if not exists idx_command_usage_time_cmd on command_usage (timestamp DESC, command_name);

--- a/scripts/migrate_add_command_usage.py
+++ b/scripts/migrate_add_command_usage.py
@@ -1,0 +1,92 @@
+"""Idempotent migration: create command_usage table + index.
+
+Captures slash-command + button + select-menu usage so we can later prune
+unused features. The bot's on_interaction listener writes rows; this
+script is for getting the table onto an existing DB that was created
+before the schema added it.
+
+Usage:
+    python3 scripts/migrate_add_command_usage.py path/to/database.sqlite [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+CREATE_TABLE_SQL = """
+create table if not exists command_usage (
+    id INTEGER not null primary key autoincrement,
+    timestamp DATETIME not null DEFAULT CURRENT_TIMESTAMP,
+    command_name TEXT not null,
+    user_id TEXT,
+    guild_id TEXT,
+    interaction_type TEXT not null
+)
+"""
+
+CREATE_INDEX_SQL = (
+    "create index if not exists idx_command_usage_time_cmd "
+    "on command_usage (timestamp DESC, command_name)"
+)
+
+
+def _table_exists(con: sqlite3.Connection, name: str) -> bool:
+    row = con.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def migrate(db_path: Path, dry_run: bool = False) -> int:
+    print(f"[migrate] target: {db_path}")
+    if not db_path.exists():
+        print(f"[migrate] ERROR: file does not exist: {db_path}")
+        return 1
+
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute("PRAGMA wal_checkpoint(FULL)")
+
+        already = _table_exists(con, "command_usage")
+        if already:
+            print("[migrate] command_usage table already present — nothing to do")
+            return 0
+
+        if dry_run:
+            print("[migrate] DRY RUN — would CREATE TABLE command_usage + index")
+            return 0
+
+        backup_path = db_path.with_name(
+            f"{db_path.stem}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}{db_path.suffix}"
+        )
+        print(f"[migrate] creating backup: {backup_path}")
+        shutil.copy2(db_path, backup_path)
+
+        print("[migrate] creating command_usage table + index...")
+        con.execute("BEGIN")
+        con.execute(CREATE_TABLE_SQL)
+        con.execute(CREATE_INDEX_SQL)
+        con.commit()
+        print("[migrate] done.")
+        return 0
+    finally:
+        con.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("db_path", type=Path, default=Path("Bot/db/database.sqlite"), nargs="?")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    return migrate(args.db_path, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds an audit log of every slash command invocation, button click, and select-menu pick so we can later see which features get used and prune the unused ones.

**Schema** — new `command_usage` table:
```sql
create table command_usage (
    id INTEGER not null primary key autoincrement,
    timestamp DATETIME not null DEFAULT CURRENT_TIMESTAMP,
    command_name TEXT not null,
    user_id TEXT,
    guild_id TEXT,
    interaction_type TEXT not null
);
create index idx_command_usage_time_cmd on command_usage (timestamp DESC, command_name);
```
Lives in `Bot/db/setup.sql` for fresh installs + `scripts/migrate_add_command_usage.py` for existing DBs (idempotent, backs up first).

**Capture** — new `Bot/cogs/usage_logger.py` cog:
- `on_interaction` listener fires on every interaction
- `_name_from_interaction` derives a stable identifier:
  - Slash commands → `/me`, `/refresh sync`, `/champ` (walks into subcommand groups)
  - Buttons → `custom_id` (e.g. `ms:panel:c0`)
  - Selects → `custom_id` (we want command-usage, not pick-distribution)
  - Skips autocomplete + modal_submit (low-signal noise)
- Insert is in try/except — DB-locked or table-missing never breaks the user's interaction

**Query** — `/usage_stats [days=7] [top=25]` admin slash command:
- Role-gated on `Keeper of Chomage` (same pattern as the other admin commands)
- Returns an ephemeral embed with the top-N commands by call count + unique users
- Footer shows total events + cutoff

**Deploy steps**
1. Merge this PR
2. Prod cron pulls
3. `ssh root@192.168.0.3 "pct exec 103 -- bash -c 'cd /root/ChomageBot && python3 scripts/migrate_add_command_usage.py Bot/db/database.sqlite'"`
4. Restart the bot container (auto_reload can't add a NEW cog without a restart): `docker compose restart` inside container 103
5. `/refresh sync` in chommage_admin to register `/usage_stats`
6. Use the bot for a bit then run `/usage_stats` to see early data

**Validation**
- `ruff check` clean
- `py_compile` clean
- Local end-to-end migration test: fresh setup.sql includes the table, dry-run + migrate + idempotent re-run all work.
