### PR TITLE
feat: role from Riot played-position + dynamic panel ordering

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -40,6 +40,27 @@ DEFAULT_BACKFILL_COUNT = 100
 STREAM_RECENT_COUNT = 5  # How many recent IDs the stream checks per player
 
 
+def _participant_position(participant: dict) -> str | None:
+    """The role Riot says this participant actually played.
+
+    Prefer ``teamPosition`` (Riot's role-classifier output: TOP / JUNGLE /
+    MIDDLE / BOTTOM / UTILITY). It's empty "" on remakes and some very old
+    matches, so fall back to ``individualPosition`` — same vocabulary, but
+    it can read "Invalid". When neither yields a usable value we store
+    NULL and let ``load_matches`` fall back to the CHAMPION_ROLES heuristic.
+
+    The raw Riot string is stored verbatim; the MIDDLE->MID / BOTTOM->ADC /
+    UTILITY->SUPPORT mapping to display roles happens at read time.
+    """
+    for key in ("teamPosition", "individualPosition"):
+        value = participant.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+            if value and value.lower() != "invalid":
+                return value
+    return None
+
+
 class Backfill(commands.Cog):
     """Backfill commands + always-on streaming for match_stats."""
 
@@ -325,8 +346,9 @@ class Backfill(commands.Cog):
                     await db.execute(
                         "INSERT OR IGNORE INTO match_stats "
                         "(match_id, puuid, game_start, queue_id, champion, "
-                        " win, kills, deaths, assists, duration_sec, patch_version) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        " win, kills, deaths, assists, duration_sec, patch_version, "
+                        " position) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                         (
                             mid,
                             puuid,
@@ -339,6 +361,7 @@ class Backfill(commands.Cog):
                             participant["assists"],
                             match["info"]["gameDuration"],
                             match["info"].get("gameVersion"),
+                            _participant_position(participant),
                         ),
                     )
                     await db.commit()

--- a/Bot/cogs/match_analysis.py
+++ b/Bot/cogs/match_analysis.py
@@ -28,6 +28,8 @@ import asyncio
 import datetime as dt
 import io
 import logging
+import re
+import sqlite3
 import time
 
 import discord
@@ -333,6 +335,61 @@ MORE_CHART_DEFS = [
         "Per-champion monthly WR shifts (finer than quarterly meta chart)",
     ),
 ]
+
+
+# Matches the canonical-index custom_ids on both the panel buttons
+# (ms:panel:cN) and the explorer buttons (ms:expl:cN). The person select
+# (ms:panel:person…) deliberately doesn't match — it isn't a chart.
+_CHART_CUSTOM_ID_RE = re.compile(r"^ms:(?:panel|expl):c(\d+)$")
+
+# The chart pinned to the first slot regardless of popularity. Index 0 is
+# also the default chart opened on a person-pick, so keeping it first keeps
+# the panel's visual lead-in and the default view aligned.
+_PINNED_CHART_IDX = 0
+
+
+def _chart_display_order(db_path: str) -> list[int]:
+    """Canonical CHART_DEFS indices ordered most-clicked-first for display.
+
+    Reads click counts from ``command_usage`` (both panel and in-explorer
+    chart buttons, which share the canonical ``cN`` index), and returns a
+    permutation of ``range(len(CHART_DEFS))``:
+
+      - ``_PINNED_CHART_IDX`` (Summary) always lands first.
+      - remaining charts sort by descending click count.
+      - canonical index breaks ties — so with no usage data the result is
+        the canonical order, and the layout only diverges as real clicks
+        accumulate.
+
+    Never raises: any DB error (missing table pre-migration, locked file)
+    falls back to canonical order. Returns CANONICAL indices, not slots —
+    the caller keeps ``custom_id``/callbacks bound to these so dispatch,
+    the usage decoder, and historical rows all stay valid.
+    """
+    n = len(CHART_DEFS)
+    canonical = list(range(n))
+    counts: dict[int, int] = {}
+    try:
+        with sqlite3.connect(db_path) as con:
+            rows = con.execute(
+                "SELECT command_name, COUNT(*) FROM command_usage "
+                "WHERE command_name LIKE 'ms:panel:c%' OR command_name LIKE 'ms:expl:c%' "
+                "GROUP BY command_name"
+            ).fetchall()
+        for name, cnt in rows:
+            m = _CHART_CUSTOM_ID_RE.match(name or "")
+            if m:
+                idx = int(m.group(1))
+                if 0 <= idx < n:
+                    counts[idx] = counts.get(idx, 0) + int(cnt)
+    except Exception as exc:
+        log.info(f"chart display-order: usage read failed ({exc!r}), using canonical order")
+        return canonical
+
+    return sorted(
+        canonical,
+        key=lambda i: (i != _PINNED_CHART_IDX, -counts.get(i, 0), i),
+    )
 
 
 def _figure_to_file(fig, name: str = "chart.png") -> discord.File:
@@ -895,7 +952,19 @@ class _ExplorerView(discord.ui.View):
         # iter 38+ charts) are reachable via the More-select instead.
         max_buttons = 19
         for idx, (label, emoji, _, _) in enumerate(CHART_DEFS[:max_buttons]):
-            button = discord.ui.Button(label=label, emoji=emoji, row=1 + (idx // 5))
+            # Canonical-index custom_id so usage_logger can attribute each
+            # click to a specific chart. Without it these ephemeral-view
+            # buttons get auto-generated ids and their clicks are invisible
+            # — which is exactly the signal the panel's dynamic ordering
+            # needs. The id is unique within the view (distinct idx) and
+            # safe across concurrent explorers (non-persistent views route
+            # by message id, so identical ids don't collide).
+            button = discord.ui.Button(
+                label=label,
+                emoji=emoji,
+                row=1 + (idx // 5),
+                custom_id=f"ms:expl:c{idx}",
+            )
             button.callback = self._make_chart_callback(idx)
             self.add_item(button)
 
@@ -1094,7 +1163,7 @@ class MatchStatsPanel(discord.ui.View):
     options don't matter for callback dispatch — discord.py routes by
     custom_id)."""
 
-    def __init__(self, df=None):
+    def __init__(self, df=None, display_order: list[int] | None = None):
         super().__init__(timeout=None)
 
         if df is not None:
@@ -1118,8 +1187,17 @@ class MatchStatsPanel(discord.ui.View):
         select.callback = self._on_select
         self.add_item(select)
 
-        for idx, (label, emoji, _, _) in enumerate(CHART_DEFS):
-            row = 1 + (idx // 5)
+        # `display_order` is a permutation of canonical CHART_DEFS indices
+        # controlling VISUAL placement only (most-clicked first, Summary
+        # pinned). custom_id + callback stay bound to the canonical index
+        # `idx`, so dispatch, the usage decoder, and historical cN rows are
+        # unaffected by reordering. None (e.g. the persistence stub) renders
+        # canonical order — dispatch doesn't care about order anyway.
+        if display_order is None:
+            display_order = list(range(len(CHART_DEFS)))
+        for slot, idx in enumerate(display_order):
+            label, emoji, _, _ = CHART_DEFS[idx]
+            row = 1 + (slot // 5)
             button = discord.ui.Button(
                 label=label,
                 emoji=emoji,
@@ -1383,7 +1461,14 @@ class MatchAnalysis(commands.Cog):
         bot lacks send permission; other exceptions propagate.
         """
         df = await _load_matches_cached(self.bot.db_path)
-        view = MatchStatsPanel(df=df if not df.empty else None)
+        # Order the chart buttons most-clicked-first (Summary pinned),
+        # recomputed on every (re)post from the live usage log. Off the
+        # event loop — it's a quick read but still touches disk.
+        display_order = await asyncio.to_thread(_chart_display_order, self.bot.db_path)
+        view = MatchStatsPanel(
+            df=df if not df.empty else None,
+            display_order=display_order,
+        )
         msg = await channel.send(
             embed=_build_panel_embed(),
             view=view,

--- a/Bot/cogs/usage_logger.py
+++ b/Bot/cogs/usage_logger.py
@@ -191,10 +191,13 @@ class UsageLogger(commands.Cog):
             if ma_cog is not None:
                 from cogs import match_analysis as ma
 
-                # CHART_DEFS is (label, emoji, fn, title) — indexed by cN
+                # CHART_DEFS is (label, emoji, fn, title) — indexed by cN.
+                # Both the panel (ms:panel:cN) and the in-explorer chart
+                # buttons (ms:expl:cN) key by the same canonical index.
                 for idx, entry in enumerate(ma.CHART_DEFS):
                     label = entry[0]
                     panel_labels[f"ms:panel:c{idx}"] = f"button: {label}"
+                    panel_labels[f"ms:expl:c{idx}"] = f"explorer: {label}"
                 panel_labels[ma.PANEL_SELECT_ID] = "panel person select"
 
                 # MORE_CHART_DEFS is (stem, label, emoji, description)

--- a/Bot/db/setup.sql
+++ b/Bot/db/setup.sql
@@ -54,6 +54,12 @@ create table if not exists match_stats (
     assists INTEGER not null,
     duration_sec INTEGER not null,
     patch_version TEXT,
+    -- Riot Match-V5 `teamPosition` (TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY), the
+    -- actual role played that game. Empty "" on remakes / very old matches;
+    -- NULL on rows inserted before this column existed. load_matches maps
+    -- these to ROLE_ORDER and falls back to the CHAMPION_ROLES heuristic when
+    -- absent. Existing DBs migrate via scripts/migrate_add_position.py.
+    position TEXT,
     primary key (match_id, puuid)
 );
 create index if not exists idx_match_stats_puuid_time on match_stats (puuid, game_start DESC);

--- a/Bot/utils/match_analysis.py
+++ b/Bot/utils/match_analysis.py
@@ -69,7 +69,24 @@ RANK_GAP_HOURS = 24 * 30
 ROLE_ORDER = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"]
 
 
-# Heuristic primary-role mapping; some champs flex (e.g. Sett: top/support — we say TOP).
+# Riot Match-V5 `teamPosition`/`individualPosition` vocabulary mapped to our
+# display roles. Riot says MIDDLE/BOTTOM/UTILITY; we show MID/ADC/SUPPORT.
+# Anything not in here (e.g. "" on remakes, "Invalid") falls through to the
+# CHAMPION_ROLES heuristic in load_matches.
+POSITION_TO_ROLE: dict[str, str] = {
+    "TOP": "TOP",
+    "JUNGLE": "JUNGLE",
+    "MIDDLE": "MID",
+    "BOTTOM": "ADC",
+    "UTILITY": "SUPPORT",
+}
+
+
+# Heuristic primary-role fallback for rows with no Riot position (matches
+# older than Riot's ~2yr retention window can never be backfilled, and
+# remakes carry an empty teamPosition). The actual played position from
+# match_stats.position is preferred; this only fills the gaps.
+# Some champs flex (e.g. Sett: top/support — we say TOP).
 # Keys match the Riot internal `dataName` (Chogath, Leblanc, FiddleSticks, MonkeyKing, ...)
 # as stored in match_stats.champion. Champions not present here resolve to "UNKNOWN" and
 # are skipped by the per-role winrate chart.
@@ -673,8 +690,14 @@ def load_matches(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
     is meaningful per account, not per person).
     """
     with sqlite3.connect(db_path) as con:
+        # `position` was added late (scripts/migrate_add_position.py). Select
+        # it only if present so a code deploy that lands before the migration
+        # has run doesn't crash every chart with "no such column"; the role
+        # derivation below already falls back to the heuristic when it's NULL.
+        ms_cols = {row[1] for row in con.execute("PRAGMA table_info(match_stats)").fetchall()}
+        position_select = "ms.position" if "position" in ms_cols else "NULL AS position"
         df = pd.read_sql_query(
-            """
+            f"""
             SELECT
                 ms.match_id,
                 ms.puuid,
@@ -687,6 +710,7 @@ def load_matches(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
                 ms.assists,
                 ms.duration_sec,
                 ms.patch_version,
+                {position_select},
                 lp.league_username AS riot_account,
                 lp.discord_user_id,
                 COALESCE(
@@ -712,7 +736,14 @@ def load_matches(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
     df["duration_bucket"] = pd.cut(
         df["duration_min"], bins=DURATION_BINS_MIN, labels=DURATION_LABELS, right=False
     )
-    df["role"] = df["champion"].map(CHAMPION_ROLES).fillna("UNKNOWN")
+    # Role = the position Riot recorded as actually played, mapped to our
+    # display vocabulary. Rows with no usable position (NULL on un-backfilled
+    # rows, "" on remakes, "Invalid") fall back to the CHAMPION_ROLES heuristic
+    # and finally "UNKNOWN". (The SELECT above always yields a `position`
+    # column — real or `NULL AS position` on un-migrated DBs.)
+    riot_role = df["position"].astype("string").str.strip().str.upper().map(POSITION_TO_ROLE)
+    heuristic_role = df["champion"].map(CHAMPION_ROLES)
+    df["role"] = riot_role.fillna(heuristic_role).fillna("UNKNOWN")
 
     # Per-person time-series features (treats multi-account users as one
     # continuous game stream — sorted by game_start so the streak/gap

--- a/scripts/backfill_position.py
+++ b/scripts/backfill_position.py
@@ -100,9 +100,7 @@ async def _fetch_positions(match_id: str) -> tuple[int, dict[str, str] | None]:
 
 def _queue_null_match_ids(con: sqlite3.Connection) -> list[str]:
     rows = con.execute(
-        "SELECT DISTINCT match_id FROM match_stats "
-        "WHERE position IS NULL "
-        "ORDER BY match_id"
+        "SELECT DISTINCT match_id FROM match_stats " "WHERE position IS NULL " "ORDER BY match_id"
     ).fetchall()
     return [r[0] for r in rows]
 

--- a/scripts/backfill_position.py
+++ b/scripts/backfill_position.py
@@ -1,0 +1,227 @@
+"""Backfill ``match_stats.position`` from Match-V5 for historical rows.
+
+We added a nullable ``position`` column to ``match_stats`` and the
+backfill cog started populating it from each participant's
+``teamPosition`` going forward. Existing rows are NULL. This script
+re-fetches Match-V5 for each distinct match_id that still has a NULL
+position on any of its rows and writes the played position back per
+``(match_id, puuid)``.
+
+Unlike the patch_version backfill, position is **per-participant**: one
+match fetch yields a different position for each tracked puuid in that
+match. We build a puuid -> position map from ``info.participants`` and
+UPDATE every NULL row for that match in a single pass.
+
+Idempotent: a re-run only processes match_ids that still have a NULL
+position, and the UPDATE re-asserts ``position IS NULL`` so it never
+clobbers a value the live ``stream_matches`` loop wrote between SELECT
+and UPDATE.
+
+Rows that resolve to an empty/Invalid Riot position are written as the
+empty string "" (not left NULL) so a re-run doesn't keep re-fetching a
+match that genuinely has no position (remakes). load_matches treats ""
+the same as NULL — it falls back to the CHAMPION_ROLES heuristic.
+
+Rate limiting: uses ``Bot.utils.riot_client`` so the dev-tier global
+budget (20 req/s, 100 req/2min) is honoured by the same limiter the live
+bot uses — roughly 0.83 req/s sustained.
+
+Usage:
+    python scripts/backfill_position.py [path/to/database.sqlite] [--dry-run] [--limit N]
+
+    --dry-run   Count + sample 5 IDs, no API calls, no DB writes.
+    --limit N   Stop after N matches successfully processed.
+
+Requires ``riot_key`` env var (loaded from .env at the project root, same
+as Bot/main.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Make Bot.utils importable when running from project root.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "Bot"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+# .env lives at the project root (same convention as Bot/main.py).
+load_dotenv(_PROJECT_ROOT / ".env")
+
+from utils.riot_client import REGION_HOST, _get_json  # noqa: E402
+
+
+def _participant_position(participant: dict) -> str:
+    """Riot's recorded played position, or "" when none is usable.
+
+    Mirrors ``cogs.backfill._participant_position`` (kept in sync by hand
+    — this one-shot script avoids importing the discord-dependent cog).
+    Returns "" rather than None so the backfill can mark genuinely
+    position-less matches (remakes) as processed.
+    """
+    for key in ("teamPosition", "individualPosition"):
+        value = participant.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+            if value and value.lower() != "invalid":
+                return value
+    return ""
+
+
+async def _fetch_positions(match_id: str) -> tuple[int, dict[str, str] | None]:
+    """Fetch Match-V5 and return ``(status, {puuid: position})``.
+
+    Status is the HTTP status (0 on network failure). The dict maps every
+    participant's puuid to its position string ("" if none usable), or
+    None on any failure / malformed body.
+    """
+    url = f"{REGION_HOST}/lol/match/v5/matches/{match_id}"
+    status, body = await _get_json(url)
+    if status != 200 or not isinstance(body, dict):
+        return status, None
+    info = body.get("info")
+    if not isinstance(info, dict):
+        return status, None
+    participants = info.get("participants")
+    if not isinstance(participants, list):
+        return status, None
+    positions: dict[str, str] = {}
+    for p in participants:
+        if isinstance(p, dict) and isinstance(p.get("puuid"), str):
+            positions[p["puuid"]] = _participant_position(p)
+    return status, positions
+
+
+def _queue_null_match_ids(con: sqlite3.Connection) -> list[str]:
+    rows = con.execute(
+        "SELECT DISTINCT match_id FROM match_stats "
+        "WHERE position IS NULL "
+        "ORDER BY match_id"
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+async def backfill(db_path: Path, limit: int | None) -> int:
+    if not db_path.exists():
+        print(f"[backfill] ERROR: file does not exist: {db_path}")
+        return 1
+
+    if not os.environ.get("riot_key"):
+        print("[backfill] ERROR: riot_key env var not set (looked in .env at project root)")
+        return 2
+
+    con = sqlite3.connect(db_path)
+    try:
+        match_ids = _queue_null_match_ids(con)
+        total = len(match_ids)
+        print(f"[backfill] {total:,} distinct match_ids with NULL position")
+        if limit is not None:
+            print(f"[backfill] --limit {limit} (will stop after {limit} matches processed)")
+
+        # 100 req / 2min => ~0.83 req/s sustained.
+        eta_minutes = (total * 120) / 100 / 60
+        print(
+            f"[backfill] dev-tier limit ~0.83 req/s sustained => "
+            f"ETA ~{eta_minutes:.0f} minutes for {total:,} matches"
+        )
+        print("[backfill] using Bot.utils.riot_client (shared rate limiter)")
+
+        succeeded = 0  # matches with at least one row updated
+        rows_updated = 0
+        not_found = 0  # 404 — Match-V5 prunes matches older than ~2 years
+        failed = 0  # other non-200 / network errors
+
+        for idx, match_id in enumerate(match_ids, start=1):
+            status, positions = await _fetch_positions(match_id)
+            if status == 200 and positions is not None:
+                match_rows = 0
+                for puuid, position in positions.items():
+                    # Re-assert position IS NULL so we never clobber a value
+                    # stream_matches may have written between SELECT and UPDATE.
+                    cur = con.execute(
+                        "UPDATE match_stats SET position = ? "
+                        "WHERE match_id = ? AND puuid = ? AND position IS NULL",
+                        (position, match_id, puuid),
+                    )
+                    match_rows += cur.rowcount
+                con.commit()
+                succeeded += 1
+                rows_updated += match_rows
+                print(f"[{idx}/{total}] {match_id} -> {match_rows} row(s) updated")
+                if limit is not None and succeeded >= limit:
+                    print(f"[backfill] --limit reached ({limit}); stopping.")
+                    break
+            elif status == 404:
+                not_found += 1
+                print(f"[{idx}/{total}] {match_id} -> 404 (expired, skipped)")
+            else:
+                failed += 1
+                print(f"[{idx}/{total}] {match_id} -> status={status} (failed)")
+
+        print("[backfill] summary:")
+        print(f"  matches processed: {succeeded} ({rows_updated} rows updated)")
+        print(f"  not_found (404 expired): {not_found}")
+        print(f"  failed (other): {failed}")
+        remaining = total - succeeded - not_found - failed
+        if remaining > 0:
+            print(f"  not_processed (limit/abort): {remaining}")
+        return 0
+    finally:
+        con.close()
+
+
+def _dry_run(db_path: Path) -> int:
+    if not db_path.exists():
+        print(f"[backfill] ERROR: file does not exist: {db_path}")
+        return 1
+    con = sqlite3.connect(db_path)
+    try:
+        match_ids = _queue_null_match_ids(con)
+        total = len(match_ids)
+        print(f"[backfill] DRY RUN — {total:,} distinct match_ids would be fetched")
+        for sample in match_ids[:5]:
+            print(f"  sample: {sample}")
+        eta_minutes = (total * 120) / 100 / 60
+        print(f"[backfill] DRY RUN — estimated wall time: ~{eta_minutes:.0f} minutes")
+        return 0
+    finally:
+        con.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "db_path",
+        type=Path,
+        nargs="?",
+        default=Path("Bot/db/database.sqlite"),
+        help="path to database.sqlite (default: Bot/db/database.sqlite)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="count NULL rows + show 5 sample IDs, no API calls",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="stop after N matches processed (for incremental runs)",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        return _dry_run(args.db_path)
+    return asyncio.run(backfill(args.db_path, limit=args.limit))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_add_position.py
+++ b/scripts/migrate_add_position.py
@@ -1,0 +1,130 @@
+"""Add a nullable ``position`` column to ``match_stats``.
+
+Match-V5 participant objects include ``teamPosition`` (TOP / JUNGLE /
+MIDDLE / BOTTOM / UTILITY) — the role Riot recorded as actually played.
+We started capturing it on INSERT, but existing DBs were created before
+the column existed. This script adds the column idempotently so old DBs
+catch up to setup.sql.
+
+What this script does, in one transaction:
+  1. Take a timestamped backup of the .sqlite file next to the original.
+  2. Detect whether ``position`` already exists on match_stats. If so,
+     exit 0 (idempotent).
+  3. ALTER TABLE match_stats ADD COLUMN position TEXT.
+  4. Verify the row count is unchanged.
+
+What it does NOT do:
+  * Backfill ``position`` for existing rows. That requires a fresh
+    Match-V5 fetch per match and is a separate (expensive) operation —
+    see scripts/backfill_position.py.
+  * Touch any other table.
+
+Idempotent: a second run sees the column is already present and exits
+without writing.
+
+Usage:
+    python scripts/migrate_add_position.py path/to/database.sqlite
+    python scripts/migrate_add_position.py --dry-run path/to/database.sqlite
+
+Run against a synced local copy first to verify before doing it on prod.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def _column_names(con: sqlite3.Connection) -> tuple[str, ...]:
+    cols = con.execute("PRAGMA table_info(match_stats)").fetchall()
+    return tuple(name for _cid, name, *_rest in cols)
+
+
+def _row_count(con: sqlite3.Connection) -> int:
+    return con.execute("SELECT COUNT(*) FROM match_stats").fetchone()[0]
+
+
+def migrate(db_path: Path, dry_run: bool = False) -> int:
+    print(f"[migrate] target: {db_path}")
+    if not db_path.exists():
+        print(f"[migrate] ERROR: file does not exist: {db_path}")
+        return 1
+
+    con = sqlite3.connect(db_path)
+    try:
+        # Ensure WAL writers have flushed before we rewrite the table.
+        con.execute("PRAGMA wal_checkpoint(FULL)")
+
+        columns = _column_names(con)
+        before = _row_count(con)
+        print(f"[migrate] current columns on match_stats: {columns}")
+        print(f"[migrate] {before:,} rows currently in match_stats")
+
+        if "position" in columns:
+            print("[migrate] position column already present — nothing to do")
+            return 0
+
+        if dry_run:
+            print("[migrate] DRY RUN — would ADD COLUMN position TEXT to match_stats")
+            print(f"[migrate] DRY RUN — expected post-migration rows: {before:,}")
+            return 0
+
+        backup_path = db_path.with_name(
+            f"{db_path.stem}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}{db_path.suffix}"
+        )
+        print(f"[migrate] creating backup: {backup_path}")
+        shutil.copy2(db_path, backup_path)
+
+        print("[migrate] adding position column…")
+        con.execute("BEGIN")
+        con.execute("ALTER TABLE match_stats ADD COLUMN position TEXT")
+        con.commit()
+
+        after = _row_count(con)
+        new_columns = _column_names(con)
+        print(f"[migrate] new columns: {new_columns}")
+        print(f"[migrate] post-migration row count: {after:,}")
+        if after != before:
+            print(
+                f"[migrate] ERROR: row count changed ({before} -> {after}); backup at {backup_path}"
+            )
+            return 3
+        if "position" not in new_columns:
+            print(f"[migrate] ERROR: position not added; backup at {backup_path}")
+            return 4
+
+        print("[migrate] done.")
+        print("[migrate] Existing rows have NULL position. New inserts via the")
+        print("[migrate] backfill cog will populate it from participant['teamPosition'].")
+        print("[migrate] Backfill historical rows with scripts/backfill_position.py.")
+        return 0
+    finally:
+        con.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "db_path",
+        type=Path,
+        nargs="?",
+        default=Path("Bot/db/database.sqlite"),
+        help="path to database.sqlite (default: Bot/db/database.sqlite)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="diagnose current columns + row count, don't modify the DB",
+    )
+    args = parser.parse_args()
+    return migrate(args.db_path, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

Two fixes to the match-stats system.

### 1. Role comes from the actual played position (Riot API), not a champion heuristic
`match_stats.role` was inferred from a hardcoded `CHAMPION_ROLES` map, so an Aatrox played mid was always labelled **TOP**. Now it comes from Match-V5's `teamPosition`.

- `setup.sql`: nullable `position TEXT` on `match_stats`.
- backfill cog: `_participant_position()` (prefers `teamPosition`, falls back to `individualPosition`, ignores `""`/`Invalid`), captured on insert — covers both `/backfill_all` and the `stream_matches` loop.
- `load_matches`: selects `position` (PRAGMA-guarded → `NULL` on un-migrated DBs) and derives role as **position → `CHAMPION_ROLES` heuristic → UNKNOWN**. The heuristic stays as a last-resort fallback because Riot retains only ~2 yr of matches, so the oldest rows can never get a real position.
- `scripts/migrate_add_position.py` + `scripts/backfill_position.py` (re-fetch Match-V5; update per `(match_id, puuid)`).

Verified end-to-end: Aatrox-played-MID → MID (overrides heuristic TOP); NULL/remake `""` rows fall back cleanly; pre-migration `NULL AS position` path doesn't crash.

### 2. Dynamic panel order by click count (replaces the requested static reorder)
Live usage was too thin for a one-time shuffle (5 single panel clicks, 15 charts with zero, over 4 days), and most real clicks were on explorer buttons logged as opaque auto-ids. A dynamic order self-corrects as clicks accumulate.

- Panel chart buttons render **most-clicked-first, Summary pinned at slot 0**, recomputed on every (re)post.
- `CHART_DEFS` stays **frozen**; a separate `display_order` controls placement only. custom_ids stay canonical (`cN` = the chart, not the slot) → dispatch, the `/usage_stats` decoder, and historical `cN` rows stay valid (no one-way reorder burn).
- Explorer buttons get stable `ms:expl:cN` custom_ids so their clicks — previously invisible — now feed the order and decode in `/usage_stats`. Explorer visual order left canonical (reordering it risks dropping a chart that isn't in the "More ▾" menu).

## Deploy steps (order matters)
1. ✅ **Migrate prod** — already run on container 103 (`position` column added, 8,168 rows intact, backup at `database.backup-20260529-125131.sqlite`).
2. **Merge this PR → main** — the deploy cron pulls main within ~2 min and hot-reloads cogs. (Pushing this branch does **not** trigger a deploy; only main does.)
3. **Backfill historical rows** — run `scripts/backfill_position.py` on 103 (~2.2 hr, 6,667 distinct matches; >2-yr-old matches 404 and keep the heuristic). Best done **after** merge so the script is present on prod.
4. **Re-run `/match_stats_panel`** — reposts with the new dynamic order + refreshed labels.

## Notes
- The write path (`_insert_matches`) names `position` unconditionally, so the **migrate-before-merge** order is required (done in step 1). The read path is already resilient to a missing column.
- Persistent-view dispatch after a restart is reasoned-correct (canonical registration) but only the live bot truly exercises it.
- Tested: `ruff` clean, byte-compiles, role-derivation + display-order logic verified against synthetic + real-schema fixtures.
