### PR TITLE
refactor: drop hardcoded champion-role map + hot-reload utils/ changes

### DIFF
--- a/Bot/cogs/auto_reload.py
+++ b/Bot/cogs/auto_reload.py
@@ -1,21 +1,39 @@
 import glob
+import importlib
 import logging
 import os
+import pathlib
+import re
+import sys
 
 from discord.ext import commands, tasks
 
 log = logging.getLogger(__name__)
 
 COG_DIR = "./cogs"
+UTILS_DIR = "./utils"
 POLL_SECONDS = 30
+
+# Reloading ourselves mid-loop would cancel this very watch task, so the
+# utils-triggered "reload every cog" pass skips this extension.
+_SELF_EXT = "cogs.auto_reload"
 
 
 class AutoReload(commands.Cog):
-    """Watches cog files for changes and hot-reloads any that change.
+    """Watches cog AND utils files for changes and hot-reloads in-process.
 
     Pairs with scripts/deploy.sh: cron pulls latest main, mtimes shift,
-    this cog reloads the affected extensions in-process. No restart, no
-    signals, no external IPC. The bot's Discord connection stays open.
+    this cog reloads the affected code in-process. No restart, no signals,
+    no external IPC. The bot's Discord connection stays open.
+
+    - ``cogs/*.py`` changed  → ``reload_extension`` for that cog.
+    - ``utils/*.py`` changed → ``importlib.reload`` that module, THEN reload
+      every loaded cog. The second step is required because
+      ``reload_extension`` does NOT reload imported submodules, and cog
+      module-level constants bake in references to utils objects at import
+      time (e.g. ``cogs.match_analysis.CHART_DEFS`` holds
+      ``utils.match_analysis.plot_*`` functions). Without it, ``utils``
+      edits silently needed a full bot restart to take effect.
     """
 
     def __init__(self, bot: commands.Bot):
@@ -28,6 +46,33 @@ class AutoReload(commands.Cog):
 
     @tasks.loop(seconds=POLL_SECONDS)
     async def watch(self) -> None:
+        # 1. utils/*.py — reload changed modules, then reload all cogs so
+        #    their import-time bindings pick up the new code. If a module
+        #    reload fails we do NOT go on to reload cogs: importlib.reload can
+        #    leave a module half-executed, and reloading cogs against that
+        #    would run their setup/cog_unload against inconsistent code.
+        changed_utils = self._detect_changed(UTILS_DIR)
+        if changed_utils:
+            if self._reload_modules(changed_utils):
+                await self._reload_all_cogs(reason="utils change")
+                # We just reloaded every loaded cog; refresh the mtime baseline
+                # for cogs we already track so the per-cog pass below doesn't
+                # reload them a second time. (New, never-seen cog files are
+                # left untouched so step 2 still loads them.)
+                for path in glob.glob(f"{COG_DIR}/*.py"):
+                    if path in self._mtimes:
+                        try:
+                            self._mtimes[path] = os.path.getmtime(path)
+                        except OSError:
+                            pass
+            else:
+                log.error(
+                    "AutoReload: a utils reload failed — skipping the cog "
+                    "reload so cogs don't bind against half-reloaded modules. "
+                    "Fix the util module; the next change will retry."
+                )
+
+        # 2. cogs/*.py — reload (or first-time load) changed cogs.
         for path in sorted(glob.glob(f"{COG_DIR}/*.py")):
             try:
                 mtime = os.path.getmtime(path)
@@ -54,6 +99,103 @@ class AutoReload(commands.Cog):
                 except Exception as exc:
                     log.error(f"AutoReload: failed to reload {ext_name}: {exc}")
                 self._mtimes[path] = mtime
+
+    def _detect_changed(self, directory: str) -> list[str]:
+        """Paths under ``directory`` whose mtime changed since last poll.
+
+        Updates the baseline as it goes. First sight of a file records its
+        mtime WITHOUT flagging it, so a restart doesn't reload everything on
+        the first tick.
+        """
+        changed: list[str] = []
+        for path in sorted(glob.glob(f"{directory}/*.py")):
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                continue
+            prev = self._mtimes.get(path)
+            if prev is None:
+                self._mtimes[path] = mtime
+            elif mtime != prev:
+                changed.append(path)
+                self._mtimes[path] = mtime
+        return changed
+
+    def _reload_modules(self, paths: list[str]) -> bool:
+        """Reload changed utils modules in place, plus any loaded utils module
+        that imports one of them.
+
+        The dependent reload is what fixes stale bindings: a module that did
+        ``from utils.changed import foo`` keeps the OLD ``foo`` until it is
+        itself re-executed, so we reload those dependents after the modules
+        they import. Changed modules go first so dependents re-bind against
+        fresh code. Returns True only if every reload succeeded; the caller
+        uses that to decide whether it's safe to reload cogs.
+
+        We do NOT blanket-reload every ``utils.*`` module — only the changed
+        ones and their importers — so an edit to one util doesn't re-run
+        unrelated module-level state (e.g. reset riot_client's rate limiter).
+        This resolves the codebase's depth-1 utils graph (riot_stats imports
+        riot_client) in one pass; any deeper chain settles on the next poll.
+        """
+        changed = {f"utils.{os.path.basename(p)[:-3]}" for p in paths}
+        ok = True
+
+        def _reload(name: str) -> None:
+            nonlocal ok
+            mod = sys.modules.get(name)
+            if mod is None:
+                # Not imported yet (or under another name) — a later cog
+                # reload will import the fresh version anyway.
+                return
+            try:
+                importlib.reload(mod)
+                log.info(f"AutoReload: reloaded module {name}")
+            except Exception as exc:
+                log.error(f"AutoReload: failed to reload module {name}: {exc}")
+                ok = False
+
+        # 1. The changed modules themselves.
+        for name in sorted(changed):
+            _reload(name)
+        # 2. Loaded utils modules that import a changed one, so their
+        #    from-imports re-point to the reloaded objects.
+        for name, mod in list(sys.modules.items()):
+            if (
+                name.startswith("utils.")
+                and name not in changed
+                and self._imports_any(mod, changed)
+            ):
+                _reload(name)
+        return ok
+
+    @staticmethod
+    def _imports_any(mod, module_names: set[str]) -> bool:
+        """True if ``mod``'s source imports any of ``module_names`` (matches
+        both ``import utils.x`` and ``from utils.x import ...``)."""
+        path = getattr(mod, "__file__", None)
+        if not path:
+            return False
+        try:
+            src = pathlib.Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return False
+        return any(
+            re.search(rf"(?:from|import)\s+{re.escape(name)}\b", src) for name in module_names
+        )
+
+    async def _reload_all_cogs(self, *, reason: str) -> None:
+        """Reload every loaded cog except ourselves. On failure discord.py
+        rolls the extension back to its previous version, so a broken edit
+        can't leave a cog unloaded."""
+        for ext_name in list(self.bot.extensions):
+            if ext_name == _SELF_EXT:
+                continue
+            try:
+                await self.bot.reload_extension(ext_name)
+                log.info(f"AutoReload: reloaded {ext_name} ({reason})")
+            except Exception as exc:
+                log.error(f"AutoReload: failed to reload {ext_name}: {exc}")
 
     @watch.before_loop
     async def before_watch(self) -> None:

--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -47,7 +47,8 @@ def _participant_position(participant: dict) -> str | None:
     MIDDLE / BOTTOM / UTILITY). It's empty "" on remakes and some very old
     matches, so fall back to ``individualPosition`` — same vocabulary, but
     it can read "Invalid". When neither yields a usable value we store
-    NULL and let ``load_matches`` fall back to the CHAMPION_ROLES heuristic.
+    NULL, and ``load_matches`` resolves the role to "UNKNOWN" (no
+    champion-based guessing).
 
     The raw Riot string is stored verbatim; the MIDDLE->MID / BOTTOM->ADC /
     UTILITY->SUPPORT mapping to display roles happens at read time.

--- a/Bot/cogs/match_analysis.py
+++ b/Bot/cogs/match_analysis.py
@@ -2074,7 +2074,14 @@ class MatchAnalysis(commands.Cog):
                 banner_lines.append(f"**{br['person']}** — {int(br['n'])} games ({p_wr:.0%})")
             embed.add_field(name="🚩 Banner picks", value="\n".join(banner_lines), inline=False)
 
-        role = analysis.CHAMPION_ROLES.get(champ_name, "?")
+        # Role from the positions actually played in our data (no hardcoded
+        # champ->role map) — show the most common one + its share.
+        role_counts = sel.loc[sel["role"].isin(analysis.ROLE_ORDER), "role"].value_counts()
+        if not role_counts.empty:
+            top_role = role_counts.index[0]
+            role = f"{top_role} ({role_counts.iloc[0] / role_counts.sum():.0%})"
+        else:
+            role = "unknown"
         embed.set_footer(
             text=f"Role: {role} · Played by {sel['person'].nunique()} different people"
         )

--- a/Bot/db/setup.sql
+++ b/Bot/db/setup.sql
@@ -57,8 +57,9 @@ create table if not exists match_stats (
     -- Riot Match-V5 `teamPosition` (TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY), the
     -- actual role played that game. Empty "" on remakes / very old matches;
     -- NULL on rows inserted before this column existed. load_matches maps
-    -- these to ROLE_ORDER and falls back to the CHAMPION_ROLES heuristic when
-    -- absent. Existing DBs migrate via scripts/migrate_add_position.py.
+    -- these to ROLE_ORDER; absent/unmapped values resolve to "UNKNOWN" (no
+    -- champion-based guessing). Existing DBs migrate via
+    -- scripts/migrate_add_position.py.
     position TEXT,
     primary key (match_id, puuid)
 );

--- a/Bot/utils/match_analysis.py
+++ b/Bot/utils/match_analysis.py
@@ -71,202 +71,14 @@ ROLE_ORDER = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"]
 
 # Riot Match-V5 `teamPosition`/`individualPosition` vocabulary mapped to our
 # display roles. Riot says MIDDLE/BOTTOM/UTILITY; we show MID/ADC/SUPPORT.
-# Anything not in here (e.g. "" on remakes, "Invalid") falls through to the
-# CHAMPION_ROLES heuristic in load_matches.
+# Anything not in here (e.g. "" on remakes, "Invalid") resolves to "UNKNOWN"
+# in load_matches — we never guess a role from the champion.
 POSITION_TO_ROLE: dict[str, str] = {
     "TOP": "TOP",
     "JUNGLE": "JUNGLE",
     "MIDDLE": "MID",
     "BOTTOM": "ADC",
     "UTILITY": "SUPPORT",
-}
-
-
-# Heuristic primary-role fallback for rows with no Riot position (matches
-# older than Riot's ~2yr retention window can never be backfilled, and
-# remakes carry an empty teamPosition). The actual played position from
-# match_stats.position is preferred; this only fills the gaps.
-# Some champs flex (e.g. Sett: top/support — we say TOP).
-# Keys match the Riot internal `dataName` (Chogath, Leblanc, FiddleSticks, MonkeyKing, ...)
-# as stored in match_stats.champion. Champions not present here resolve to "UNKNOWN" and
-# are skipped by the per-role winrate chart.
-CHAMPION_ROLES: dict[str, str] = {
-    # TOP
-    "Aatrox": "TOP",
-    "Ambessa": "TOP",
-    "Camille": "TOP",
-    "Chogath": "TOP",
-    "Darius": "TOP",
-    "DrMundo": "TOP",
-    "Fiora": "TOP",
-    "Gangplank": "TOP",
-    "Garen": "TOP",
-    "Gnar": "TOP",
-    "Gwen": "TOP",
-    "Illaoi": "TOP",
-    "Irelia": "TOP",
-    "Jax": "TOP",
-    "Jayce": "TOP",
-    "Kayle": "TOP",
-    "Kennen": "TOP",
-    "Kled": "TOP",
-    "KSante": "TOP",
-    "Malphite": "TOP",
-    "Mordekaiser": "TOP",
-    "Nasus": "TOP",
-    "Ornn": "TOP",
-    "Pantheon": "TOP",
-    "Poppy": "TOP",
-    "Quinn": "TOP",
-    "Renekton": "TOP",
-    "Riven": "TOP",
-    "Rumble": "TOP",
-    "Sett": "TOP",
-    "Shen": "TOP",
-    "Singed": "TOP",
-    "Sion": "TOP",
-    "Teemo": "TOP",
-    "Tryndamere": "TOP",
-    "Urgot": "TOP",
-    "Vladimir": "TOP",
-    "Volibear": "TOP",
-    "Warwick": "TOP",
-    "Yasuo": "TOP",
-    "Yorick": "TOP",
-    # JUNGLE
-    "Amumu": "JUNGLE",
-    "Belveth": "JUNGLE",
-    "Briar": "JUNGLE",
-    "Diana": "JUNGLE",
-    "Ekko": "JUNGLE",
-    "Elise": "JUNGLE",
-    "Evelynn": "JUNGLE",
-    "FiddleSticks": "JUNGLE",
-    "Gragas": "JUNGLE",
-    "Graves": "JUNGLE",
-    "Hecarim": "JUNGLE",
-    "Ivern": "JUNGLE",
-    "JarvanIV": "JUNGLE",
-    "Karthus": "JUNGLE",
-    "Kayn": "JUNGLE",
-    "Khazix": "JUNGLE",
-    "Kindred": "JUNGLE",
-    "LeeSin": "JUNGLE",
-    "Lillia": "JUNGLE",
-    "MasterYi": "JUNGLE",
-    "MonkeyKing": "JUNGLE",
-    "Naafiri": "JUNGLE",
-    "Nidalee": "JUNGLE",
-    "Nocturne": "JUNGLE",
-    "Nunu": "JUNGLE",
-    "Olaf": "JUNGLE",
-    "Rammus": "JUNGLE",
-    "RekSai": "JUNGLE",
-    "Rengar": "JUNGLE",
-    "Sejuani": "JUNGLE",
-    "Shaco": "JUNGLE",
-    "Shyvana": "JUNGLE",
-    "Skarner": "JUNGLE",
-    "Trundle": "JUNGLE",
-    "Udyr": "JUNGLE",
-    "Vi": "JUNGLE",
-    "Viego": "JUNGLE",
-    "XinZhao": "JUNGLE",
-    "Zac": "JUNGLE",
-    # MID
-    "Ahri": "MID",
-    "Akali": "MID",
-    "Akshan": "MID",
-    "Anivia": "MID",
-    "Annie": "MID",
-    "AurelionSol": "MID",
-    "Aurora": "MID",
-    "Azir": "MID",
-    "Cassiopeia": "MID",
-    "Fizz": "MID",
-    "Galio": "MID",
-    "Heimerdinger": "MID",
-    "Hwei": "MID",
-    "Kassadin": "MID",
-    "Katarina": "MID",
-    "Leblanc": "MID",
-    "Lissandra": "MID",
-    "Lux": "MID",
-    "Malzahar": "MID",
-    "Neeko": "MID",
-    "Orianna": "MID",
-    "Qiyana": "MID",
-    "Ryze": "MID",
-    "Sylas": "MID",
-    "Syndra": "MID",
-    "Taliyah": "MID",
-    "Talon": "MID",
-    "TwistedFate": "MID",
-    "Veigar": "MID",
-    "Velkoz": "MID",
-    "Vex": "MID",
-    "Viktor": "MID",
-    "Xerath": "MID",
-    "Yone": "MID",
-    "Zed": "MID",
-    "Ziggs": "MID",
-    "Zoe": "MID",
-    # ADC
-    "Aphelios": "ADC",
-    "Ashe": "ADC",
-    "Caitlyn": "ADC",
-    "Corki": "ADC",
-    "Draven": "ADC",
-    "Ezreal": "ADC",
-    "Jhin": "ADC",
-    "Jinx": "ADC",
-    "Kaisa": "ADC",
-    "Kalista": "ADC",
-    "KogMaw": "ADC",
-    "Lucian": "ADC",
-    "MissFortune": "ADC",
-    "Nilah": "ADC",
-    "Samira": "ADC",
-    "Senna": "ADC",
-    "Sivir": "ADC",
-    "Smolder": "ADC",
-    "Tristana": "ADC",
-    "Twitch": "ADC",
-    "Varus": "ADC",
-    "Vayne": "ADC",
-    "Xayah": "ADC",
-    "Yunara": "ADC",
-    "Zeri": "ADC",
-    # SUPPORT
-    "Alistar": "SUPPORT",
-    "Bard": "SUPPORT",
-    "Blitzcrank": "SUPPORT",
-    "Brand": "SUPPORT",
-    "Braum": "SUPPORT",
-    "Janna": "SUPPORT",
-    "Karma": "SUPPORT",
-    "Leona": "SUPPORT",
-    "Lulu": "SUPPORT",
-    "Maokai": "SUPPORT",
-    "Mel": "SUPPORT",
-    "Milio": "SUPPORT",
-    "Morgana": "SUPPORT",
-    "Nami": "SUPPORT",
-    "Nautilus": "SUPPORT",
-    "Pyke": "SUPPORT",
-    "Rakan": "SUPPORT",
-    "Rell": "SUPPORT",
-    "Renata": "SUPPORT",
-    "Seraphine": "SUPPORT",
-    "Sona": "SUPPORT",
-    "Soraka": "SUPPORT",
-    "Swain": "SUPPORT",
-    "TahmKench": "SUPPORT",
-    "Taric": "SUPPORT",
-    "Thresh": "SUPPORT",
-    "Yuumi": "SUPPORT",
-    "Zilean": "SUPPORT",
-    "Zyra": "SUPPORT",
 }
 
 
@@ -737,13 +549,19 @@ def load_matches(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
         df["duration_min"], bins=DURATION_BINS_MIN, labels=DURATION_LABELS, right=False
     )
     # Role = the position Riot recorded as actually played, mapped to our
-    # display vocabulary. Rows with no usable position (NULL on un-backfilled
-    # rows, "" on remakes, "Invalid") fall back to the CHAMPION_ROLES heuristic
-    # and finally "UNKNOWN". (The SELECT above always yields a `position`
+    # display vocabulary. No champion->role guessing: rows with no usable
+    # position (NULL on un-backfilled/expired matches, "" on remakes,
+    # "Invalid") resolve to "UNKNOWN" and are excluded from role charts via
+    # the ROLE_ORDER filter. (The SELECT above always yields a `position`
     # column — real or `NULL AS position` on un-migrated DBs.)
-    riot_role = df["position"].astype("string").str.strip().str.upper().map(POSITION_TO_ROLE)
-    heuristic_role = df["champion"].map(CHAMPION_ROLES)
-    df["role"] = riot_role.fillna(heuristic_role).fillna("UNKNOWN")
+    df["role"] = (
+        df["position"]
+        .astype("string")
+        .str.strip()
+        .str.upper()
+        .map(POSITION_TO_ROLE)
+        .fillna("UNKNOWN")
+    )
 
     # Per-person time-series features (treats multi-account users as one
     # continuous game stream — sorted by game_start so the streak/gap
@@ -6140,10 +5958,10 @@ def plot_champion_freshness(df: pd.DataFrame, player: str | None = None) -> plt.
 
 
 def plot_role_winrate(df: pd.DataFrame, player: str | None = None) -> plt.Figure:
-    """Win rate split by inferred champion role.
+    """Win rate split by the role actually played.
 
-    Role is a heuristic from CHAMPION_ROLES — champions that flex get
-    their more common role. Rows with an unmapped champion (role
+    Role comes from Riot's recorded position (match_stats.position) mapped
+    to TOP/JUNGLE/MID/ADC/SUPPORT. Rows with no usable position (role
     "UNKNOWN") are skipped.
 
     Per-person: bars are coloured against the player's overall baseline


### PR DESCRIPTION
## What & why

Follow-up to #50. Two related changes.

### 1. Drop the hardcoded `CHAMPION_ROLES` map entirely
Per the original intent of #50: role should come from the **position actually played**, never a hardcoded champion→role guess. Now that the position backfill is done, only ~5 of ~8.2k rows lack a real position, so the heuristic map has no real job left.

- **`utils/match_analysis.py`**: deleted the ~180-line `CHAMPION_ROLES` dict. `load_matches` derives `role = POSITION_TO_ROLE(position)` else `"UNKNOWN"` (rows with no usable position — expired/un-backfilled matches, remakes `""`, `"Invalid"` — resolve to UNKNOWN and are excluded from role charts via the `ROLE_ORDER` filter).
- **`cogs/match_analysis.py`** (`/champ`): footer role now shows the most-played role **from the data** (e.g. `Role: MID (94%)`) instead of the dropped lookup.
- **`setup.sql` / `backfill.py`**: comments updated to drop heuristic references.

### 2. `auto_reload` now hot-reloads `utils/` changes too
`auto_reload` only watched `cogs/*.py` and called `reload_extension`, which does **not** reload imported submodules. So edits to `utils/*.py` silently needed a full bot restart to take effect — which bit us twice: the position-role logic (in `utils/`) didn't go live after deploy, and a stale `ALL_PLOTS` dropped half the analytics charts from the explorer's More menu for days.

Now a changed `utils/*.py` is `importlib.reload`-ed in place, then every loaded cog is reloaded so import-time bindings (e.g. `CHART_DEFS` holding `utils` plot fns) pick up the new code.

Safety details:
- Skips reloading `auto_reload` itself (would cancel the running watch loop).
- If a util `importlib.reload` raises, the cog reload is **skipped** (cogs never bind against a half-reloaded module); the next change retries.
- Refreshes cog mtime baselines after a utils-triggered reload to avoid a redundant second pass; new/unseen cog files are still picked up.
- `reload_extension` rolls back on failure, so a broken edit can't leave a cog unloaded.
- Reloads only the *changed* util module (not all of `utils.*`) to avoid re-running module-level state like `riot_client`'s rate limiter on unrelated edits; the near-flat utils graph makes sibling-binding staleness negligible.

## Reviews done
- **Code review (high effort):** no correctness blockers; verified role NaN handling and the `/champ` `sel["role"]` access.
- **Codex review:** 0 critical; 2 should-fix on `auto_reload`. Addressed #1 (short-circuit cog reload on util-reload failure); #2 (reload sibling utils) accepted+documented for the reasons above.

## Deploy note
Because change #2 lands first via cron+cog-reload, **this is the last change that needs a manual `docker restart`** — after it's live, future `utils/` edits hot-reload on their own. Suggested order: merge → restart once → from then on `utils/` deploys are automatic.
