### PR TITLE
feat(charts): 2026 role-performance matrix + promote to button

### DIFF
--- a/Bot/cogs/match_analysis.py
+++ b/Bot/cogs/match_analysis.py
@@ -180,6 +180,12 @@ CHART_DEFS = [
         analysis.plot_duo_winrate,
         "Duos (same team) + head-to-head (opposite teams)",
     ),
+    (
+        "Role matrix",
+        "🧭",
+        analysis.plot_player_role_matrix,
+        "2026 role performance vs each account's own WR",
+    ),
 ]
 
 # Charts only reachable via the explorer's "More ▾" select. Stems must
@@ -188,12 +194,8 @@ CHART_DEFS = [
 MORE_CHART_DEFS = [
     ("21_duo_winrate", "Duos / H2H", "🤝", "Same-team partnerships + head-to-head"),
     ("30_role_winrate", "Per-role WR", "🛡️", "WR per role (TOP/JG/MID/ADC/SUP) with Wilson CIs"),
-    (
-        "31_player_role_matrix",
-        "Role matrix",
-        "🧭",
-        "Player×role heatmap vs personal baseline (aggregate only)",
-    ),
+    # 31_player_role_matrix promoted to a main chart button (CHART_DEFS) — it's
+    # the "Role matrix" button now, no longer in this overflow menu.
     ("32_tilt_by_gap", "Tilt analysis", "😤", "After-loss vs after-win WR by inter-game gap"),
     (
         "33_session_position_wr",

--- a/Bot/utils/match_analysis.py
+++ b/Bot/utils/match_analysis.py
@@ -6092,136 +6092,132 @@ def plot_role_winrate(df: pd.DataFrame, player: str | None = None) -> plt.Figure
 
 
 def plot_player_role_matrix(df: pd.DataFrame, player: str | None = None) -> plt.Figure:
-    """Player x role WR heatmap, coloured by each row's gap to that
-    player's own overall WR.
+    """Account x role performance matrix (2026 games only).
 
-    A flat heatmap of role WRs would be dominated by the fact that some
-    players are just better than others. Re-centring each row on the
-    player's personal baseline pulls out the role-specific story: who
-    over-performs on jungle relative to their own mean, who tanks on
-    support, etc.
+    A heatmap: each cell is one Riot account's win rate in one role,
+    coloured by the gap to that account's own overall 2026 WR (green = a
+    role they're better at than their average, red = worse, +/-10pp). The
+    cell prints WR + games (n), plus a small recent-form marker — up arrow
+    / down arrow when their last-30-day WR in that role is notably above /
+    below their 2026 WR there (>=8 recent games). Re-centring on each
+    account's baseline pulls out the role story rather than just "who's
+    better overall".
 
-    Aggregate-only: per-person view returns an empty figure pointing the
-    reader back to the dropdown.
+    Split by actual Riot account (not the person rollup). Rows are accounts
+    with >=10 2026 role-mapped games (up to 20, most-active first); a cell is
+    coloured only when the account has >=10 such games in that role.
+    Aggregate-only — the per-person view points back to the dropdown.
     """
+    import matplotlib as mpl
+
     if not _is_aggregate(player):
         return _empty_figure("Aggregate view only - pick 'All' from the dropdown")
 
-    mapped = df[df["role"].isin(ROLE_ORDER)]
+    mapped = df[df["role"].isin(ROLE_ORDER)].copy()
+    mapped["game_start"] = pd.to_datetime(mapped["game_start"])
+    mapped = mapped[mapped["game_start"] >= pd.Timestamp("2026-01-01")]
     if mapped.empty:
-        return _empty_figure("No matches with a mapped role")
+        return _empty_figure("No 2026 matches with a mapped role")
 
-    # Per-player totals come from mapped games only — the same basis the
-    # cells and baselines use, so the n shown beside the row matches the
-    # n the baseline was computed from.
-    totals = mapped.groupby("person").agg(games=("win", "size"), wins=("win", "sum")).reset_index()
-    totals = totals[totals["games"] >= 100]
-    if totals.empty:
-        return _empty_figure("No player has >=100 mapped games")
-    totals["wr"] = totals["wins"] / totals["games"]
-    totals = totals.sort_values("games", ascending=False).head(10).reset_index(drop=True)
-    players = totals["person"].tolist()
-
-    cell = (
-        mapped[mapped["person"].isin(players)]
-        .groupby(["person", "role"])
-        .agg(games=("win", "size"), wins=("win", "sum"))
-        .reset_index()
+    totals = (
+        mapped.groupby("riot_account").agg(games=("win", "size"), wins=("win", "sum")).reset_index()
     )
-    cell["wr"] = cell["wins"] / cell["games"]
+    totals = totals[totals["games"] >= 10]
+    if totals.empty:
+        return _empty_figure("No account has >=10 mapped games in 2026")
+    totals["wr"] = totals["wins"] / totals["games"]
+    totals = totals.sort_values("games", ascending=False).head(20).reset_index(drop=True)
+    accounts = totals["riot_account"].tolist()
+    baseline = dict(zip(totals["riot_account"], totals["wr"], strict=False))
 
-    n_players = len(players)
-    n_roles = len(ROLE_ORDER)
-    wr_grid = np.full((n_players, n_roles), np.nan)
-    games_grid = np.zeros((n_players, n_roles), dtype=int)
-    delta_grid = np.full((n_players, n_roles), np.nan)
+    # Recent-form window: last 30 days, anchored to the latest game in the
+    # data (robust to when the chart is rendered).
+    recent_cut = mapped["game_start"].max() - pd.Timedelta(days=30)
 
-    baseline_by_person = dict(zip(totals["person"], totals["wr"], strict=False))
-    for _, row in cell.iterrows():
-        pi = players.index(row["person"])
-        ri = ROLE_ORDER.index(row["role"])
-        games_grid[pi, ri] = int(row["games"])
-        if row["games"] >= 15:
-            wr_grid[pi, ri] = float(row["wr"])
-            delta_grid[pi, ri] = float(row["wr"]) - baseline_by_person[row["person"]]
+    n_rows = len(accounts)
+    n_cols = len(ROLE_ORDER)
+    wr_grid = np.full((n_rows, n_cols), np.nan)
+    games_grid = np.zeros((n_rows, n_cols), dtype=int)
+    delta_grid = np.full((n_rows, n_cols), np.nan)
+    marker_grid: dict[tuple[int, int], str] = {}
 
-    # Colour scale: clip delta to +/-10pp, map to RdYlGn so the strongest
-    # over-/under-performers anchor the extremes. Anything inside the band
-    # interpolates linearly. set_bad paints low-n cells grey via NaN.
-    import matplotlib as mpl
+    for pi, acct in enumerate(accounts):
+        for ri, role in enumerate(ROLE_ORDER):
+            sub = mapped[(mapped["riot_account"] == acct) & (mapped["role"] == role)]
+            n = len(sub)
+            games_grid[pi, ri] = n
+            if n < 10:
+                continue
+            cell_wr = float(sub["win"].mean())
+            wr_grid[pi, ri] = cell_wr
+            delta_grid[pi, ri] = cell_wr - baseline[acct]
+            recent = sub[sub["game_start"] >= recent_cut]
+            if len(recent) >= 8:
+                rdelta = float(recent["win"].mean()) - cell_wr
+                if rdelta >= 0.05:
+                    marker_grid[(pi, ri)] = "▲"
+                elif rdelta <= -0.05:
+                    marker_grid[(pi, ri)] = "▼"
 
     cmap = mpl.colormaps.get_cmap("RdYlGn").copy()
     cmap.set_bad(color="#dcdcdc")
     norm = mpl.colors.Normalize(vmin=-0.10, vmax=0.10)
-    # delta_grid carries NaN where games < 15, so masking is automatic.
     colour_data = np.clip(delta_grid, -0.10, 0.10)
 
     fig, (ax, cax) = plt.subplots(
-        1, 2, figsize=(11.5, 0.55 * n_players + 2.5), gridspec_kw={"width_ratios": [22, 1]}
+        1, 2, figsize=(11.5, 0.55 * n_rows + 2.5), gridspec_kw={"width_ratios": [22, 1]}
     )
     im = ax.imshow(colour_data, cmap=cmap, norm=norm, aspect="auto")
 
-    ax.set_xticks(np.arange(n_roles))
+    ax.set_xticks(np.arange(n_cols))
     ax.set_xticklabels(ROLE_ORDER)
-    ax.set_yticks(np.arange(n_players))
-    # Bake the personal baseline into the y-tick label — keeps the layout
-    # simple (no extra axes to fight tight_layout) and puts the reference
-    # number physically next to the row it belongs to.
+    ax.set_yticks(np.arange(n_rows))
     ax.set_yticklabels(
         [
-            f"{_display_label(p) or p}\n{baseline_by_person[p]:.0%} (n={int(totals.loc[i, 'games'])})"
-            for i, p in enumerate(players)
+            f"{acct}\n{baseline[acct]:.0%} (n={int(totals.loc[i, 'games'])})"
+            for i, acct in enumerate(accounts)
         ],
         fontsize=9,
     )
 
-    for pi in range(n_players):
-        for ri in range(n_roles):
+    for pi in range(n_rows):
+        for ri in range(n_cols):
             n = games_grid[pi, ri]
-            if n < 15 or np.isnan(wr_grid[pi, ri]):
-                ax.text(
-                    ri,
-                    pi,
-                    "-",
-                    ha="center",
-                    va="center",
-                    fontsize=11,
-                    color=PALETTE["muted"],
-                )
+            if n < 10 or np.isnan(wr_grid[pi, ri]):
+                ax.text(ri, pi, "-", ha="center", va="center", fontsize=11, color=PALETTE["muted"])
                 continue
             wr = wr_grid[pi, ri]
             d = delta_grid[pi, ri]
-            # Near-baseline cells sit in the yellow zone of RdYlGn — dark
-            # text reads, white text disappears. Outside ~4pp the cmap
-            # darkens and white wins.
             txt_colour = PALETTE["text"] if abs(d) < 0.04 else "white"
             ax.text(
-                ri,
-                pi,
-                f"{wr:.0%}\nn={n}",
-                ha="center",
-                va="center",
-                fontsize=9,
-                color=txt_colour,
+                ri, pi, f"{wr:.0%}\nn={n}", ha="center", va="center", fontsize=9, color=txt_colour
             )
+            marker = marker_grid.get((pi, ri))
+            if marker:
+                ax.text(
+                    ri + 0.42,
+                    pi - 0.32,
+                    marker,
+                    ha="right",
+                    va="top",
+                    fontsize=8,
+                    color="#1a7a3a" if marker == "▲" else "#9b1c1c",
+                )
 
-    ax.set_xticks(np.arange(n_roles + 1) - 0.5, minor=True)
-    ax.set_yticks(np.arange(n_players + 1) - 0.5, minor=True)
-    ax.grid(which="minor", color="white", linewidth=2)
-    ax.tick_params(which="minor", length=0)
     ax.tick_params(which="major", length=0)
+    ax.grid(False)  # the project style enables a major grid; off for the heatmap
     for spine in ax.spines.values():
         spine.set_visible(False)
 
-    ax.set_title("Role winrate vs personal baseline")
+    ax.set_title("2026 role performance — WR vs each account's own average")
     _subtitle(
         ax,
-        "Each cell coloured by gap to player's overall WR "
-        "(red below, green above, +/-10pp). Cells with <15 games shown grey.",
+        "Cell coloured by gap to the account's overall 2026 WR (red below, green above, +/-10pp). "
+        "▲/▼ = last-30d WR in that role notably above/below. Cells with <10 games shown grey.",
     )
 
     cbar = fig.colorbar(im, cax=cax)
-    cbar.set_label("Delta vs personal baseline (pp)")
+    cbar.set_label("Delta vs account's 2026 WR (pp)")
     cbar.set_ticks([-0.10, -0.05, 0.0, 0.05, 0.10])
     cbar.ax.set_yticklabels(["-10", "-5", "0", "+5", "+10"])
 


### PR DESCRIPTION
## What & why

Reworks chart 31 into a focused **2026 role-performance matrix** and promotes it to a **one-click button** (out of the explorer's "More ▾").

The old chart graphed cumulative WR over time, which isn't useful — it just converges to the headline number and the month-to-month wiggle is mostly variance. This version answers the real question: *which roles does each account over/under-perform in, how much do they play them, and who's trending.*

### Chart (`utils/match_analysis.py` → `plot_player_role_matrix`)
- **2026 games only**, split by **actual Riot account** (not the person rollup).
- Rows = accounts with **≥10** 2026 role-mapped games (top 20 by volume); a cell is coloured only at **≥10** games in that role (was 100/15).
- Each cell = WR **coloured by gap to that account's own 2026 WR** (green above / red below, ±10pp RdYlGn), printing **WR + n** (volume), grey `-` for low-sample.
- **▲/▼ recent-form marker** when last-30d WR in that role is notably (±5pp) above/below the account's WR there (needs ≥8 recent games).
- Dropped the white inter-cell gridlines + the project style's major grid.

### Wiring (`cogs/match_analysis.py`)
- Added **"Role matrix"** to `CHART_DEFS` (now a button, canonical index 20).
- Removed `31_player_role_matrix` from `MORE_CHART_DEFS`. `c15..c20` stay dispatch-covered by `_PanelButtonDispatch`; `ALL_PLOTS` mapping unchanged so it's not orphaned.

## Notes
- Aggregate-only: from a person view it shows the "pick All" empty state (unchanged behaviour).
- Reviewed with Codex; rendered against a live-DB copy through several design iterations.
- Docstring is still prose — a follow-up branch converts it to NumPy style.

## Deploy
Pure cog+utils change. After merge, the new `auto_reload` (now live) hot-reloads it — no restart needed — then re-run `/match_stats_panel` to repost the board with the new button.
