### PR TITLE
refactor(db): centralize DB connections behind a factory module

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -25,10 +25,10 @@ import asyncio
 import datetime as dt
 import logging
 
-import aiosqlite as sqa
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
+from utils.db import aconnect
 from utils.riot_client import get_match, get_match_ids
 
 log = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ class Backfill(commands.Cog):
 
         count = max(1, min(count, PAGE_SIZE))
 
-        async with sqa.connect(self.bot.db_path) as db:
+        async with aconnect(self.bot.db_path) as db:
             rows = await db.execute_fetchall(
                 "SELECT puuid, league_username FROM league_players "
                 "WHERE puuid IS NOT NULL AND puuid != ''"
@@ -205,7 +205,7 @@ class Backfill(commands.Cog):
         player and insert anything new. Cheap on steady state — most calls
         return IDs we already have and skip the match-detail fetch.
         """
-        async with sqa.connect(self.bot.db_path) as db:
+        async with aconnect(self.bot.db_path) as db:
             rows = await db.execute_fetchall(
                 "SELECT puuid, league_username FROM league_players "
                 "WHERE puuid IS NOT NULL AND puuid != ''"
@@ -290,7 +290,7 @@ class Backfill(commands.Cog):
             # Filtering by match_id alone would skip games where this puuid
             # hasn't been backfilled yet but another tracked friend already
             # has — exactly the "duo's second row" case we need to pick up.
-            async with sqa.connect(self.bot.db_path) as db:
+            async with aconnect(self.bot.db_path) as db:
                 placeholders = ",".join("?" * len(ids))
                 existing_rows = await db.execute_fetchall(
                     f"SELECT match_id FROM match_stats "
@@ -343,7 +343,7 @@ class Backfill(commands.Cog):
                 game_start = dt.datetime.fromtimestamp(
                     match["info"]["gameStartTimestamp"] / 1000.0
                 ).strftime("%Y-%m-%d %H:%M:%S")
-                async with sqa.connect(self.bot.db_path) as db:
+                async with aconnect(self.bot.db_path) as db:
                     await db.execute(
                         "INSERT OR IGNORE INTO match_stats "
                         "(match_id, puuid, game_start, queue_id, champion, "

--- a/Bot/cogs/kda.py
+++ b/Bot/cogs/kda.py
@@ -1,8 +1,8 @@
-import aiosqlite as sqa
 import discord
 from discord import app_commands
 from discord.ext import commands
 from utils.autocomplete import DiscordAttachedLeagueNames
+from utils.db import aconnect
 from utils.riot_stats import fetch_recent_kd
 
 MATCH_COUNT = 20
@@ -31,7 +31,7 @@ class KdaCog(commands.Cog):
     ):
         await ctx.response.defer()
 
-        async with sqa.connect(self.bot.db_path) as db:
+        async with aconnect(self.bot.db_path) as db:
             row = await (
                 await db.execute(
                     "SELECT puuid FROM league_players WHERE league_username = ?",

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -1,12 +1,12 @@
 import asyncio
 import datetime as dt
 
-import aiosqlite as sqa
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
 from pantheon.utils.exceptions import ServerError
+from utils.db import aconnect
 from utils.rank_sorting_class import Ranker
 from utils.riot_client import get_league_entries
 from utils.riot_stats import fetch_recent_kd
@@ -73,7 +73,7 @@ class FetchFromRiot(commands.Cog):
         return users_ranks
 
     async def fetch_ranks_from_db(self):
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute_fetchall(
                 """SELECT league_username,
                         lp,
@@ -110,7 +110,7 @@ class FetchFromRiot(commands.Cog):
         # self.bot.logging.info("fetching ranks")
         # fetch from db
         # await self.fetch_ranks_from_db()
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute_fetchall(
                 """SELECT puuid,
                         IIF(nickname = '', discord_tag, nickname),
@@ -134,7 +134,7 @@ class FetchFromRiot(commands.Cog):
         # (league_players.leagueId, ~47 chars), newer rows by the real
         # puuid (~78 chars). Query both so legacy-tracked players still
         # surface their game history.
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute(
                 "SELECT wins, losses FROM league_history "
                 "WHERE puuid IN ("
@@ -178,7 +178,7 @@ class FetchFromRiot(commands.Cog):
         if losses could have come last. False-negatives over false-positives
         for the ping.
         """
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute(
                 "SELECT wins, losses FROM league_history "
                 "WHERE puuid IN ("
@@ -228,7 +228,7 @@ class FetchFromRiot(commands.Cog):
         await channel.send(f"\U0001faf5\U0001f602 <@{user_id}>{extra}")
 
     async def get_name(self, puuid):
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute_fetchall(
                 "SELECT league_username FROM league_players WHERE puuid = ?",
                 (puuid,),
@@ -239,7 +239,7 @@ class FetchFromRiot(commands.Cog):
                     return "Unknown"
 
     async def check_name(self, puuid):
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             async with connection.execute_fetchall(
                 "SELECT puuid, league_username FROM league_players WHERE puuid = ?",
                 (puuid,),
@@ -479,7 +479,7 @@ class FetchFromRiot(commands.Cog):
 
     # Needs updating to grab last match from the table
     async def update_table(self, user, user_stats_dict):
-        async with sqa.connect(database=self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             try:
                 self.bot.logging.info(f"updating table, logging {user_stats_dict}")
                 last_values = await connection.execute_fetchall(
@@ -498,7 +498,7 @@ class FetchFromRiot(commands.Cog):
         except Exception as e:
             self.bot.logging.info(f"Exception as {e}")
 
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             await connection.execute(
                 "INSERT INTO league_history (puuid, lp, division, tier, wins, losses) VALUES (?, ?, ?, ?, ?, ?)",
                 (

--- a/Bot/cogs/league_user_updater.py
+++ b/Bot/cogs/league_user_updater.py
@@ -1,9 +1,9 @@
-import aiosqlite as sqa
 import discord
 from discord import app_commands
 from discord.ext import commands
 from main import MyDiscordBot
 from utils.autocomplete import DiscordAttachedLeagueNames
+from utils.db import aconnect
 
 
 class LeagueUsers(commands.Cog):
@@ -27,7 +27,7 @@ class LeagueUsers(commands.Cog):
         # Get PUUID from Account API - this is all we need now
         puuid = (await self.bot.lolapi.get_account_by_riotId(league_name, tagline))["puuid"]
 
-        async with sqa.connect(self.bot.db_path) as db:
+        async with aconnect(self.bot.db_path) as db:
             await db.execute(
                 """REPLACE INTO league_players (
                         discord_user_id,
@@ -62,7 +62,7 @@ class LeagueUsers(commands.Cog):
     ):
         if league_name != "":
             names = league_name.split(";")
-            async with sqa.connect(self.bot.db_path) as db:
+            async with aconnect(self.bot.db_path) as db:
                 for name in names:
                     await db.execute(
                         "DELETE FROM league_players WHERE league_username = ?", (name,)
@@ -71,7 +71,7 @@ class LeagueUsers(commands.Cog):
                     await ctx.response.send_message(f"{name} removed from list")
 
         else:
-            async with sqa.connect(self.bot.db_path) as db:
+            async with aconnect(self.bot.db_path) as db:
                 await db.execute("DELETE FROM league_players WHERE discord_user_id = ?", (user.id,))
                 await db.commit()
                 await ctx.response.send_message(
@@ -85,7 +85,7 @@ class LeagueUsers(commands.Cog):
         description="Shows all player currently stored in the league database",
     )
     async def show_all(self, ctx: discord.Interaction):
-        async with sqa.connect(self.bot.db_path) as db:
+        async with aconnect(self.bot.db_path) as db:
             to_show = await db.execute_fetchall("SELECT league_username, tag FROM league_players")
         to_print = ""
         for name in to_show:

--- a/Bot/cogs/match_analysis.py
+++ b/Bot/cogs/match_analysis.py
@@ -29,7 +29,6 @@ import datetime as dt
 import io
 import logging
 import re
-import sqlite3
 import time
 
 import discord
@@ -41,6 +40,7 @@ import matplotlib.pyplot as plt
 from discord import app_commands
 from discord.ext import commands, tasks
 from utils import match_analysis as analysis
+from utils.db import connect
 
 log = logging.getLogger(__name__)
 
@@ -387,7 +387,7 @@ def _chart_display_order(db_path: str) -> list[int]:
     canonical = list(range(n))
     counts: dict[int, int] = {}
     try:
-        with sqlite3.connect(db_path) as con:
+        with connect(db_path) as con:
             rows = con.execute(
                 "SELECT command_name, COUNT(*) FROM command_usage "
                 "WHERE command_name LIKE 'ms:panel:c%' OR command_name LIKE 'ms:expl:c%' "

--- a/Bot/cogs/ranked_graphing.py
+++ b/Bot/cogs/ranked_graphing.py
@@ -2,7 +2,6 @@ import datetime as dt
 import os
 import pickle
 
-import aiosqlite as sqa
 import discord
 import matplotlib.pyplot as plt
 from discord import app_commands
@@ -10,6 +9,7 @@ from discord.ext import commands
 from main import MyDiscordBot
 from utils.add_a_cheg import ChegClass
 from utils.autocomplete import DiscordAttachedLeagueNames
+from utils.db import aconnect
 from utils.rank_sorting_class import Ranker
 
 # Start of the current ranked tracking window. Update manually when a new
@@ -34,7 +34,7 @@ class LeagueGraphs(commands.Cog):
         user: discord.User,
         league_name: app_commands.Transform[str, DiscordAttachedLeagueNames],
     ):
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             summonerid = await connection.execute_fetchall(
                 "SELECT leagueId FROM league_players WHERE league_username = ?",
                 (league_name,),
@@ -55,7 +55,7 @@ class LeagueGraphs(commands.Cog):
             pickle.load(f)
 
             # plt._backend_mod.new_figure_manager_given_figure(1, fig)
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             # Older history rows are keyed by the legacy 47-char summoner ID
             # (league_players.leagueId), newer rows by the real 78-char puuid.
             # Match on either via a UNION subquery so legacy-tracked players
@@ -81,7 +81,7 @@ class LeagueGraphs(commands.Cog):
             )
             return
 
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             user = await connection.execute_fetchall(
                 "SELECT league_username FROM league_players WHERE leagueId = ?",
                 (summonerid[0][0],),
@@ -118,7 +118,7 @@ class LeagueGraphs(commands.Cog):
         user: discord.User,
         league_name: app_commands.Transform[str, DiscordAttachedLeagueNames],
     ):
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             summonerid = await connection.execute_fetchall(
                 "SELECT leagueId FROM league_players WHERE league_username = ?",
                 (league_name,),
@@ -138,7 +138,7 @@ class LeagueGraphs(commands.Cog):
             pickle.load(f)
 
         # plt._backend_mod.new_figure_manager_given_figure(1, fig)
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             # See generate_singular: match both legacy leagueId and modern
             # puuid via UNION so legacy-tracked players surface correctly.
             async with connection.execute(
@@ -157,7 +157,7 @@ class LeagueGraphs(commands.Cog):
                         score_dict[key] = []
                     score_dict[key].append(value)
 
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             user = await connection.execute_fetchall(
                 "SELECT league_username FROM league_players WHERE leagueId = ?",
                 (summonerid[0][0],),

--- a/Bot/cogs/usage_logger.py
+++ b/Bot/cogs/usage_logger.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
-import aiosqlite as sqa
 import discord
 from discord import app_commands
 from discord.ext import commands
+from utils.db import aconnect
 
 # Match the role-name gate used in cogs.match_analysis for admin commands.
 # Duplicated here (rather than imported) so this cog has no cross-cog
@@ -96,7 +96,7 @@ class UsageLogger(commands.Cog):
             interaction.type.name if hasattr(interaction.type, "name") else str(interaction.type)
         )
         try:
-            async with sqa.connect(self.bot.db_path) as db:
+            async with aconnect(self.bot.db_path) as db:
                 await db.execute(
                     "INSERT INTO command_usage "
                     "(command_name, user_id, guild_id, interaction_type) "
@@ -137,7 +137,7 @@ class UsageLogger(commands.Cog):
 
         cutoff = (dt.datetime.now() - dt.timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
         try:
-            async with sqa.connect(self.bot.db_path) as db:
+            async with aconnect(self.bot.db_path) as db:
                 rows = await db.execute_fetchall(
                     "SELECT command_name, COUNT(*) AS n, "
                     "COUNT(DISTINCT user_id) AS uniq_users "

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -2,13 +2,12 @@ import asyncio
 import glob
 import logging
 import os
-import sqlite3 as sq
 
-import aiosqlite as sqa
 import discord
 import pantheon
 from discord.ext.commands import Bot
 from dotenv import load_dotenv
+from utils import db
 from utils.db_utils import DButils
 
 # Load .env from parent directory relative to this file's location
@@ -27,6 +26,8 @@ class MyDiscordBot(Bot):
         super().__init__(command_prefix, intents=intents)
         self.dbutils = DButils(db_path=db_path)
         self.db_path = db_path
+        # Single seam for the storage backend — see utils/db.py.
+        db.configure(db_path)
         self.guildid = serverid
 
         riot_key = os.environ.get("riot_key")
@@ -52,25 +53,25 @@ class MyDiscordBot(Bot):
     async def sync_discord(self) -> None:
         print("Syncing users")
         guild = await self.fetch_guild(self.guildid)
-        async with sqa.connect(self.db_path) as db:
+        async with db.aconnect(self.db_path) as conn:
             async for member in guild.fetch_members():
                 nickname = member.nick if member.nick is not None else ""
-                await db.execute(
+                await conn.execute(
                     "REPLACE INTO users (user_id, nickname, discord_tag) VALUES (?, ?, ?)",
                     (member.id, nickname, member.name),
                 )
-                await db.commit()
+                await conn.commit()
 
             channels = await guild.fetch_channels()
 
             for channel in channels:
                 if str(channel.type) == "category":
                     continue
-                await db.execute(
+                await conn.execute(
                     "REPLACE INTO discord_channels (channel_id, name, type) VALUES (?, ?, ?)",
                     (int(channel.id), str(channel.name), str(channel.type)),
                 )
-            await db.commit()
+            await conn.commit()
         return
 
     async def on_connect(self) -> None:
@@ -97,7 +98,7 @@ def setup_db(logger: logging.Logger) -> None:
     if not os.path.isfile(db_path):
         logger.info("Creating empty database file")
         open(db_path, "x", encoding="utf-8").close()
-    with sq.connect(db_path) as connection:
+    with db.connect(db_path) as connection:
         with open("./db/setup.sql", encoding="utf-8") as f:
             connection.executescript(f.read())
     logger.info("Database schema applied")

--- a/Bot/utils/autocomplete.py
+++ b/Bot/utils/autocomplete.py
@@ -1,20 +1,21 @@
 from typing import Any
+
 import discord
 from discord import app_commands
-import aiosqlite as sqa
+from utils.db import aconnect
 
 
 class DiscordAttachedLeagueNames(app_commands.Transformer):
-
     async def transform(self, interaction: discord.Interaction, value: Any):
         return value
 
     async def autocomplete(self, interaction: discord.Interaction, value):
-        async with sqa.connect(interaction.client.db_path) as db:
+        async with aconnect(interaction.client.db_path) as db:
             db.row_factory = lambda cursor, row: row[0]
             attached_accounts = await db.execute_fetchall(
                 "SELECT league_username FROM league_players WHERE discord_user_id = ?",
-                (interaction.namespace.user.id, ))
+                (interaction.namespace.user.id,),
+            )
         return [
             app_commands.Choice(name=league_name, value=league_name)
             for league_name in attached_accounts

--- a/Bot/utils/db.py
+++ b/Bot/utils/db.py
@@ -1,0 +1,90 @@
+"""Central database connection factory.
+
+Every database connection in the bot is opened through this module so the
+storage backend lives behind a single seam. Today that backend is SQLite —
+synchronous access via :mod:`sqlite3`, asynchronous via :mod:`aiosqlite` —
+and the connection target is a filesystem path.
+
+The factories are deliberately thin pass-throughs that preserve the exact
+behaviour of the ``sqlite3.connect`` / ``aiosqlite.connect`` calls they
+replace, so swapping them in is behaviour-neutral.
+
+Scope note: centralising the *connection* is what makes a future backend
+move (e.g. Postgres) tractable — there's one place to change instead of
+~30 scattered call sites. It is **not** a literal connection-string swap on
+its own: the SQL dialect (``INSERT OR IGNORE``, ``pandas.read_sql_query``)
+and the async driver (aiosqlite vs asyncpg) still differ and would need
+their own handling. This module intentionally stays a connection factory,
+not an ORM / dialect-translation layer.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+
+# Process-wide default DB target, set once at startup via configure(). Call
+# sites may still pass an explicit path (and currently do, via bot.db_path);
+# the default is the single knob to change when the location moves.
+_db_path: str | None = None
+
+
+def configure(db_path: str) -> None:
+    """Set the process-wide default database target.
+
+    Parameters
+    ----------
+    db_path : str
+        Path to the SQLite database file. Call once during startup.
+    """
+    global _db_path
+    _db_path = db_path
+
+
+def _resolve(db_path: str | None) -> str:
+    """Return the explicit ``db_path`` if given, else the configured default.
+
+    Raises
+    ------
+    RuntimeError
+        If no path is supplied and :func:`configure` has not been called.
+    """
+    target = db_path if db_path is not None else _db_path
+    if target is None:
+        raise RuntimeError("database not configured: pass db_path or call db.configure() first")
+    return target
+
+
+def connect(db_path: str | None = None) -> sqlite3.Connection:
+    """Open a synchronous SQLite connection.
+
+    Parameters
+    ----------
+    db_path : str, optional
+        Target database; falls back to the configured default.
+
+    Returns
+    -------
+    sqlite3.Connection
+        A connection usable as a context manager, exactly as
+        ``sqlite3.connect`` returns.
+    """
+    return sqlite3.connect(_resolve(db_path))
+
+
+def aconnect(db_path: str | None = None) -> aiosqlite.Connection:
+    """Open an asynchronous (aiosqlite) SQLite connection.
+
+    Parameters
+    ----------
+    db_path : str, optional
+        Target database; falls back to the configured default.
+
+    Returns
+    -------
+    aiosqlite.Connection
+        An awaitable connection usable with ``async with``, exactly as
+        ``aiosqlite.connect`` returns.
+    """
+    return aiosqlite.connect(_resolve(db_path))

--- a/Bot/utils/db_utils.py
+++ b/Bot/utils/db_utils.py
@@ -1,6 +1,6 @@
-import re
-from typing import Iterable
-import aiosqlite as sqa
+from collections.abc import Iterable
+
+from utils.db import aconnect
 
 
 class DButils:
@@ -8,14 +8,14 @@ class DButils:
         self.db_path = db_path
 
     async def get_id_from_username(self, name) -> str:
-        async with sqa.connect(self.db_path) as connection:
+        async with aconnect(self.db_path) as connection:
             puuid = await connection.execute_fetchall(
                 "SELECT puuid FROM league_players WHERE league_username = ?", (name,)
             )
         return puuid[0][0]
 
     async def get_username_from_id(self, puuid) -> str:
-        async with sqa.connect(self.db_path) as connection:
+        async with aconnect(self.db_path) as connection:
             name = await connection.execute_fetchall(
                 "SELECT league_username FROM league_players WHERE puuid = ?", (puuid)
             )
@@ -32,6 +32,6 @@ class DButils:
                 "SELECT * FROM league_history WHERE puuid = (SELECT puuid FROM league_players WHERE league_username = ?) ORDER BY timestamp DESC LIMIT ?",
                 (player, number),
             )
-        async with sqa.connect(self.bot.db_path) as connection:
+        async with aconnect(self.bot.db_path) as connection:
             recent_matches = await connection.execute_fetchall(*sql)
         return recent_matches

--- a/Bot/utils/match_analysis.py
+++ b/Bot/utils/match_analysis.py
@@ -13,12 +13,13 @@ a fresh Figure that the caller is responsible for closing.
 from __future__ import annotations
 
 import math
-import sqlite3
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
+from .db import connect
 
 DEFAULT_DB = Path(__file__).resolve().parent.parent / "db" / "database.sqlite"
 
@@ -501,7 +502,7 @@ def load_matches(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
     available for per-account drill-downs (e.g. champion learning curve
     is meaningful per account, not per person).
     """
-    with sqlite3.connect(db_path) as con:
+    with connect(db_path) as con:
         # `position` was added late (scripts/migrate_add_position.py). Select
         # it only if present so a code deploy that lands before the migration
         # has run doesn't crash every chart with "no such column"; the role
@@ -609,7 +610,7 @@ def load_rank_history(db_path: Path = DEFAULT_DB) -> pd.DataFrame:
     """
     from utils.rank_sorting_class import Ranker
 
-    with sqlite3.connect(db_path) as con:
+    with connect(db_path) as con:
         df = pd.read_sql_query(
             """
             SELECT

--- a/Bot/utils/update_puuids.py
+++ b/Bot/utils/update_puuids.py
@@ -1,82 +1,90 @@
 """
 Script to update PUUIDs in the database using the Riot Account API
 """
+
 import asyncio
-import aiosqlite as sqa
-import aiohttp
 import os
+
+import aiohttp
 from dotenv import load_dotenv
+from utils.db import aconnect
 
 # Load environment variables
 env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".env")
 load_dotenv(env_path)
 
+
 async def update_puuids(db_path: str):
     """Update all PUUIDs in the database using the Account API"""
     riot_api_key = os.environ.get("riot_key")
-    
+
     if not riot_api_key:
         print("ERROR: riot_key not found in environment variables!")
         return
-    
+
     print(f"Riot API Key loaded: {riot_api_key[:10]}...{riot_api_key[-4:]}")
-    
-    async with sqa.connect(db_path) as db:
+
+    async with aconnect(db_path) as db:
         # Fetch all players
-        cursor = await db.execute("SELECT discord_user_id, league_username, tag FROM league_players")
+        cursor = await db.execute(
+            "SELECT discord_user_id, league_username, tag FROM league_players"
+        )
         players = await cursor.fetchall()
-        
+
         print(f"\nFound {len(players)} players to update")
         print("-" * 60)
-        
+
         updated = 0
         failed = 0
-        
+
         for discord_user_id, game_name, tag_line in players:
             try:
                 # Call Account API to get PUUID
                 # Use europe routing for EUW players
                 url = f"https://europe.api.riotgames.com/riot/account/v1/accounts/by-riot-id/{game_name}/{tag_line}"
                 headers = {"X-Riot-Token": riot_api_key}
-                
+
                 async with aiohttp.ClientSession() as session:
                     async with session.get(url, headers=headers) as response:
                         if response.status == 200:
                             account_data = await response.json()
-                            new_puuid = account_data['puuid']
-                            
+                            new_puuid = account_data["puuid"]
+
                             # Update database
                             await db.execute(
                                 "UPDATE league_players SET puuid = ? WHERE discord_user_id = ? AND league_username = ? AND tag = ?",
-                                (new_puuid, discord_user_id, game_name, tag_line)
+                                (new_puuid, discord_user_id, game_name, tag_line),
                             )
                             await db.commit()
-                            
+
                             print(f"✓ Updated {game_name}#{tag_line}")
                             updated += 1
                         elif response.status == 429:
-                            retry_after = int(response.headers.get('Retry-After', 10))
+                            retry_after = int(response.headers.get("Retry-After", 10))
                             print(f"⚠ Rate limited, waiting {retry_after} seconds...")
                             await asyncio.sleep(retry_after)
                             # Retry this one
                             continue
                         else:
                             error_text = await response.text()
-                            print(f"✗ Failed {game_name}#{tag_line}: HTTP {response.status} - {error_text}")
+                            print(
+                                f"✗ Failed {game_name}#{tag_line}: HTTP {response.status} - {error_text}"
+                            )
                             failed += 1
-                
+
                 # Small delay to avoid rate limits
                 await asyncio.sleep(0.1)
-                
+
             except Exception as e:
                 print(f"✗ Error updating {game_name}#{tag_line}: {e}")
                 failed += 1
-        
+
         print("-" * 60)
-        print(f"\nUpdate complete!")
+        print("\nUpdate complete!")
         print(f"  Updated: {updated}")
         print(f"  Failed: {failed}")
         print(f"  Total: {len(players)}")
+
 
 if __name__ == "__main__":
     db_path = "./db/database.sqlite"


### PR DESCRIPTION
## What & why

Your headline ask: make the storage backend swappable from **one place**. Adds `Bot/utils/db.py` and routes every runtime DB connection through it.

`db.py` exposes:
- `connect(db_path=None)` — sync (sqlite3)
- `aconnect(db_path=None)` — async (aiosqlite)
- `configure(db_path)` — set the process-wide default (called once at startup in `main.py`)

The factories are **thin pass-throughs** that preserve the exact behaviour of the `sqlite3.connect` / `aiosqlite.connect` calls they replace.

## Migrated (12 files)
`main.py` + cogs (`backfill`, `kda`, `usage_logger`, `league_user_updater`, `league_table_updater`, `ranked_graphing`, `match_analysis`) + utils (`match_analysis`, `db_utils`, `autocomplete`, `update_puuids`). After this, **zero** direct `sqlite3.connect`/`aiosqlite.connect` calls remain outside `db.py`.

`utils/match_analysis.py` uses a **relative** `from .db import connect` because it's imported both as `utils.*` (bot runtime) and `Bot.utils.*` (scripts/smoke test) — an absolute import breaks the latter.

## Honest scope note (also in db.py)
This is **not** a literal connection-string swap to e.g. Postgres on its own — the SQL dialect (`INSERT OR IGNORE`, `pandas.read_sql_query`) and the async driver (aiosqlite vs asyncpg) still differ. What it buys you: one seam to change instead of ~30 scattered call sites. It deliberately stays a connection factory, **not** an ORM/dialect layer.

## Verification
- Chart **smoke test 228/228** (read path through `db.connect`).
- `db.connect`/`aconnect` return correct row counts sync & async; `configure()` default-path works.
- ruff + `py_compile` clean on all changed files.
- Write paths (backfill/league_table_updater/usage_logger inserts) are behaviour-identical since `aconnect` is a pass-through; spot-checked the migrated call sites.

Part of the larger cleanup; formatting / NumPy-docstrings / simplification land as separate PRs to avoid cross-cutting collisions.