### PR TITLE
chore(ruff): format + lint the remaining non-compliant files

### DIFF
--- a/Bot/cogs/team_generator.py
+++ b/Bot/cogs/team_generator.py
@@ -1,10 +1,10 @@
-import typing
 import random
-from typing import Any, List, Union
+from typing import Any
+
 import discord
-from discord.ext import commands
-from discord import app_commands
 import numpy as np
+from discord import app_commands
+from discord.ext import commands
 
 
 class TeamGenerator(commands.Cog):
@@ -14,16 +14,14 @@ class TeamGenerator(commands.Cog):
         self.bot = bot
         self.bot.logging.info(f"{__name__} loaded")
 
-    @app_commands.command(
-        name="select_teams", description="Create a number of teams of players"
-    )
+    @app_commands.command(name="select_teams", description="Create a number of teams of players")
     @app_commands.describe(
         team_size="The size of the team",
     )
     async def generate_teams(
         self,
         ctx: discord.Interaction,
-        team_size: typing.Optional[int] = 5,
+        team_size: int | None = 5,
     ):
         """Slash command to generate teams
 
@@ -43,12 +41,11 @@ class UserDropdown(discord.ui.UserSelect):
     """Generate the dropdown component for the selection"""
 
     def __init__(self, team_size):
-
         super().__init__(placeholder="Select a user", min_values=2, max_values=25)
         self.team_size = team_size
 
     async def callback(self, interaction: discord.Interaction) -> Any:
-        members: List[Union[discord.Member, discord.User]] = self.values
+        members: list[discord.Member | discord.User] = self.values
         random.shuffle(members)
         to_send = ""
         for team_no in range(int(np.ceil(len(members) / self.team_size))):

--- a/Bot/utils/add_a_cheg.py
+++ b/Bot/utils/add_a_cheg.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-import os
 
 
 class ChegClass:
@@ -20,9 +19,7 @@ class ChegClass:
         def rotate_image(image, angle):
             image_center = tuple(np.array(image.shape[1::-1]) / 2)
             rot_mat = cv2.getRotationMatrix2D(image_center, angle, 1.0)
-            result = cv2.warpAffine(
-                image, rot_mat, image.shape[1::-1], flags=cv2.INTER_LINEAR
-            )
+            result = cv2.warpAffine(image, rot_mat, image.shape[1::-1], flags=cv2.INTER_LINEAR)
             return result
 
         foreground = rotate_image(foreground, np.random.randint(0, 360))
@@ -49,10 +46,7 @@ class ChegClass:
                 overlay = np.concatenate(
                     [
                         overlay,
-                        np.ones(
-                            (overlay.shape[0], overlay.shape[1], 1), dtype=overlay.dtype
-                        )
-                        * 255,
+                        np.ones((overlay.shape[0], overlay.shape[1], 1), dtype=overlay.dtype) * 255,
                     ],
                     axis=2,
                 )

--- a/Bot/utils/create_ranked_graph.py
+++ b/Bot/utils/create_ranked_graph.py
@@ -1,13 +1,15 @@
-from rank_sorting_class import Ranker
-import matplotlib.pyplot as plt
+import pickle
+
 import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+from rank_sorting_class import Ranker
 
 current_ticks = []
 new_ticks = []
 for league in Ranker.LEAGUES.keys():
     for subleague in Ranker.SUBLEAGUE.keys():
         x = Ranker(league, subleague, "0")
-        current_ticks.append((x._score + 50))
+        current_ticks.append(x._score + 50)
         new_ticks.append(str(x).split(" - ")[0])
 
 fig, ax = plt.subplots(figsize=(5, 5), dpi=600)
@@ -28,7 +30,7 @@ for idx, colour in enumerate(colours):
         alpha=opacity,
     )
 
-for idx, tick in enumerate(current_ticks):
+for idx in range(len(current_ticks)):
     ax.axhline(
         y=current_ticks[idx] - 50,
         linewidth=1,
@@ -42,8 +44,6 @@ ax.xaxis.set_major_locator(mdates.DayLocator(interval=7))
 ax.xaxis.set_major_formatter(mdates.DateFormatter("%0d/%m/%y"))
 plt.xticks(rotation=45, ha="center")
 
-
-import pickle
 
 with open("utils/my_fig.pickle", "wb") as f:
     pickle.dump(fig, file=f)

--- a/Bot/utils/rank_sorting_class.py
+++ b/Bot/utils/rank_sorting_class.py
@@ -27,8 +27,11 @@ class Ranker:
         self._score = self._rankToScore()
 
     def _rankToScore(self):
-
-        actual_score = 1000 * Ranker.LEAGUES[self.league] + 100 * Ranker.SUBLEAGUE[self.subleague] + int(self.leaguePoints)
+        actual_score = (
+            1000 * Ranker.LEAGUES[self.league]
+            + 100 * Ranker.SUBLEAGUE[self.subleague]
+            + int(self.leaguePoints)
+        )
         adjustment_factor = Ranker.LEAGUES[self.league] * 599
         return actual_score - adjustment_factor
 


### PR DESCRIPTION
Brings the 4 files that weren't ruff-clean up to standard: `team_generator.py`, `add_a_cheg.py`, `rank_sorting_class.py`, `create_ranked_graph.py`.

Deliberately **excludes** the files already cleaned by #55 (`autocomplete`, `db_utils`, `update_puuids`) so the two PRs don't collide on the same files.

Mostly whitespace / import-sort / trailing-comma autofixes. `create_ranked_graph.py` also hoists a stray late `import pickle` (E402) and drops an unused loop var (B007) — behaviour-neutral.

With #55 merged, the whole `Bot/` tree passes `ruff format --check` + `ruff check`. py_compile clean.