### PR TITLE
Archive full Match-V5 payloads (match_raw JSONB)

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -19,6 +19,13 @@ Both paths share the same per-player routine and are fully idempotent:
 (match_id, puuid) is the table's PRIMARY KEY, we pre-filter against
 existing IDs before any match-detail fetch, and the write uses
 INSERT ... ON CONFLICT DO NOTHING as a belt-and-braces guard.
+
+Every fetched payload is also archived verbatim into ``match_raw``
+(one row per match, JSONB) so future stat columns can be filled from
+SQL instead of a Riot re-fetch backfill. The pre-filter skips a match
+only when it is in match_stats (for this puuid) AND in match_raw:
+matches ingested before match_raw existed are therefore re-fetched —
+through the shared limiter — exactly once, healing the raw archive.
 """
 
 import asyncio
@@ -28,6 +35,7 @@ import logging
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
+from psycopg.types.json import Jsonb
 from utils import db
 from utils.loop_restart import restart_loop_later
 from utils.riot_client import get_match, get_match_ids
@@ -87,7 +95,7 @@ class Backfill(commands.Cog):
     @app_commands.guild_only()
     @app_commands.describe(
         count="Max matches per player (max 100). Ignored if all_history=True.",
-        all_history="Paginate through Riot's entire exposed history (~2y). Slow.",
+        all_history="Paginate Riot's full history (~2y); also heals matches missing raw JSON. Slow.",
     )
     async def backfill_all(
         self,
@@ -95,6 +103,16 @@ class Backfill(commands.Cog):
         count: int = DEFAULT_BACKFILL_COUNT,
         all_history: bool = False,
     ):
+        """One-shot historical pull for every tracked player.
+
+        Besides inserting missing match_stats rows, this also auto-heals
+        the match_raw archive: matches stored before raw-payload capture
+        existed fail the pre-filter and get re-fetched (match_stats
+        re-writes are ON CONFLICT DO NOTHING no-ops, so this is harmless,
+        but progress counts include those healed matches). Run with
+        all_history=True once after deploying raw capture to backfill
+        payloads for the whole history window.
+        """
         await ctx.response.defer(ephemeral=True)
 
         if self._task is not None and not self._task.done():
@@ -290,14 +308,21 @@ class Backfill(commands.Cog):
             if not ids:
                 break
 
-            # Filter out match IDs we already have stored FOR THIS puuid.
-            # Filtering by match_id alone would skip games where this puuid
-            # hasn't been backfilled yet but another tracked friend already
-            # has — exactly the "duo's second row" case we need to pick up.
+            # Skip a match only if BOTH extracts already exist:
+            #   - a match_stats row FOR THIS puuid. Filtering by match_id
+            #     alone would skip games where this puuid hasn't been
+            #     backfilled yet but another tracked friend already has —
+            #     exactly the "duo's second row" case we need to pick up.
+            #   - a match_raw row (raw payloads are per match, not per
+            #     puuid). Matches ingested before raw capture existed fail
+            #     this leg and get re-fetched once, healing the archive.
+            #     Steady state is unaffected: anything fetched after this
+            #     shipped has both rows, so the 5-min stream stays cheap.
             placeholders = ",".join(["%s"] * len(ids))
             existing_rows = await db.fetchall(
-                f"SELECT match_id FROM match_stats "
-                f"WHERE puuid = %s AND match_id IN ({placeholders})",
+                f"SELECT ms.match_id FROM match_stats ms "
+                f"JOIN match_raw mr ON mr.match_id = ms.match_id "
+                f"WHERE ms.puuid = %s AND ms.match_id IN ({placeholders})",
                 (puuid, *ids),
             )
             existing = {row[0] for row in existing_rows}
@@ -326,19 +351,33 @@ class Backfill(commands.Cog):
 
     async def _insert_matches(self, puuid: str, match_ids: list[str]) -> int:
         """Fetch + insert match details one at a time, one short statement
-        per write.
+        per write (raw payload archive, then the per-player stats row).
 
         Why per-match: bundling the whole page under one transaction
         would hold a pooled connection across N network calls
         (~50-500ms each). A one-shot ``db.execute`` per insert returns
         the connection to the pool between Riot fetches, so other
         writers interleave freely.
+
+        Returns the number of matches fetched and written through. During
+        a raw-archive heal pass the match_stats write is a conflict no-op
+        but the match still counts — the fetch genuinely happened.
         """
         inserted = 0
         for mid in match_ids:
             match = await get_match(mid)
             if match is None:
                 continue
+            # Archive the complete payload first, before any per-participant
+            # parsing, so the raw JSON survives even if extraction below
+            # ever trips on a malformed match. One row per MATCH: when a
+            # second tracked player triggers a fetch of the same game the
+            # conflict clause makes this a no-op.
+            await db.execute(
+                "INSERT INTO match_raw (match_id, payload) VALUES (%s, %s) "
+                "ON CONFLICT (match_id) DO NOTHING",
+                (mid, Jsonb(match)),
+            )
             for participant in match["info"]["participants"]:
                 if participant["puuid"] != puuid:
                     continue

--- a/Bot/db/setup.postgres.sql
+++ b/Bot/db/setup.postgres.sql
@@ -43,6 +43,11 @@ create table if not exists league_players (
 -- queue: league-v4 queueType this snapshot belongs to. Pre-existing rows
 -- migrate as RANKED_SOLO_5x5; the Ranked 5s board writes RANKED_5S
 -- (canonical internal constant — see cogs/ranked5s_table_updater.py).
+-- raw: the complete league-v4 entry this snapshot was extracted from,
+-- archived verbatim (same rationale as match_raw below: hotStreak,
+-- miniSeries, the real queueType string etc. stay queryable without a
+-- re-fetch). NULL on rows from before the column existed — league-v4 has
+-- no history endpoint, so those snapshots are unrecoverable by design.
 create table if not exists league_history (
     id BIGINT generated always as identity primary key,
     puuid TEXT not null,
@@ -52,7 +57,8 @@ create table if not exists league_history (
     tier TEXT,
     wins INTEGER,
     losses INTEGER,
-    queue TEXT not null default 'RANKED_SOLO_5x5'
+    queue TEXT not null default 'RANKED_SOLO_5x5',
+    raw JSONB
 );
 create index if not exists idx_league_history_puuid_id on league_history (puuid, id desc);
 create index if not exists idx_league_history_queue on league_history (queue);
@@ -80,6 +86,20 @@ create table if not exists match_stats (
     primary key (match_id, puuid)
 );
 create index if not exists idx_match_stats_puuid_time on match_stats (puuid, game_start desc);
+
+-- Complete Match-V5 JSON payload, archived verbatim at ingest. One row per
+-- MATCH (not per participant — tracked players often share a game; the
+-- per-player extract lives in match_stats). Exists so adding a new stat
+-- later is a JSONB query or one-off UPDATE against payload instead of a
+-- full Riot re-fetch backfill (the position column needed one; never again).
+-- Old matches ingested before this table existed are healed lazily: the
+-- backfill pre-filter re-fetches any match missing from here (see
+-- cogs/backfill.py), so a manual /backfill_all all_history=True fills it.
+create table if not exists match_raw (
+    match_id TEXT not null primary key,
+    fetched_at TIMESTAMPTZ not null default now(),
+    payload JSONB not null
+);
 
 -- Audit log of slash commands + button clicks + select-menu picks.
 create table if not exists command_usage (

--- a/docs/riot-api-reference.md
+++ b/docs/riot-api-reference.md
@@ -108,6 +108,72 @@ after the fact.
   board keeps polling for a 2 h tail after close so games in flight at 01:00
   and late LP settlement are still captured.
 
+## Raw payload capture (match_raw)
+
+Every Match-V5 payload the bot fetches is archived **verbatim** into the
+`match_raw` table (`Bot/db/setup.postgres.sql`):
+
+| column | type | meaning |
+|---|---|---|
+| `match_id` | TEXT PK | e.g. `EUW1_7371190121` — one row per **match**, not per participant |
+| `fetched_at` | TIMESTAMPTZ | when the bot pulled it |
+| `payload` | JSONB | the complete `GET /lol/match/v5/matches/{id}` response |
+
+**Why**: `match_stats` extracts only a dozen columns. When a new stat is
+wanted (the `position` column required a full, rate-limited re-fetch of ~8k
+matches), it should be a SQL query or one-off `UPDATE` against `payload`,
+never another Riot backfill. Both ingest paths in `cogs/backfill.py` (5-min
+stream and `/backfill_all`) write it with `ON CONFLICT (match_id) DO NOTHING`.
+
+### Extracting a new field with JSONB
+
+The full response shape is `metadata` (the 10 puuids) + `info` (game fields,
+`participants[10]`, `teams[2]`). To pull a participant-level field for every
+tracked-player row — here `goldEarned` — join on puuid inside the
+participants array:
+
+```sql
+SELECT ms.match_id,
+       ms.puuid,
+       (p ->> 'goldEarned')::int                 AS gold_earned,
+       (p ->> 'totalDamageDealtToChampions')::int AS champ_damage
+FROM match_stats ms
+JOIN match_raw mr ON mr.match_id = ms.match_id
+CROSS JOIN LATERAL jsonb_array_elements(mr.payload -> 'info' -> 'participants') AS p
+WHERE p ->> 'puuid' = ms.puuid;
+```
+
+Match-level fields are direct paths: `payload -> 'info' ->> 'gameVersion'`,
+`payload -> 'info' -> 'teams' -> 0 -> 'objectives' -> 'baron' ->> 'kills'`.
+
+### Auto-heal for pre-existing matches
+
+Matches ingested before `match_raw` existed have stats rows but no payload.
+The backfill pre-filter skips a match only when it is in **both**
+`match_stats` (for that puuid) **and** `match_raw`, so:
+
+- the 5-min stream stays cheap — anything fetched after this shipped has
+  both rows (it re-fetches at most the last 5 per player once, right after
+  deploy);
+- a manual `/backfill_all` with `all_history=True` re-fetches exactly the
+  old matches missing payloads, through the shared limiter, and the
+  `match_stats` conflict no-ops make the re-writes harmless. At the
+  developer-tier budget (100 req/120 s) a ~9k-match heal takes roughly
+  3 hours of residual budget, sharing with the live boards.
+
+### Storage
+
+A ranked Match-V5 payload is ~60–90 KB as JSON text (10 participants x
+~130 fields + ~110 `challenges` fields each). Stored as JSONB it lands in
+TOAST with pglz compression: a full-shape synthetic payload measured
+**44 KB `pg_column_size`** (77 KB as text); real payloads compress somewhat
+better (many zero/repeated values), so figure **~25–45 KB per match** on
+disk. For the ~9k matches in the live DB that is **~0.25–0.4 GB**, growing
+on the order of tens of MB per month at current tracked-player volume —
+comfortable on the DB container's 8 GB rootfs, but worth a
+`pg_total_relation_size('match_raw')` glance if the tracked-player list
+grows a lot.
+
 ## Sources
 
 - Riot dev blog — [/dev: The Return of Ranked 5s](https://www.leagueoflegends.com/en-us/news/dev/dev-the-return-of-ranked-5s/)


### PR DESCRIPTION
> [!NOTE]
> Stacked on #58 (Ranked 5s) → #57 (Postgres port). Diff shows only the raw-capture commit.

## What

Every fetched match payload is now archived verbatim into a new `match_raw` table (one JSONB row per match) alongside the existing `match_stats` extract — so the next time we want a stat we didn't extract (the `position` column required a full Riot re-fetch backfill), it's a SQL query against local JSONB instead of hours of rate-limited API calls.

- Raw insert happens before participant parsing, so the archive survives extraction bugs.
- Pre-filter heals itself: a match is skipped only when it's in `match_stats` **and** `match_raw`. The 5-min stream stays cheap; one manual `/backfill_all all_history=True` after deploy re-fetches exactly the ~9k legacy matches missing payloads through the shared rate limiter (~3h at dev-key budget), with conflict-no-op writes.
- `docs/riot-api-reference.md` gains a worked JSONB extraction example (per-participant fields via `jsonb_array_elements`) and the heal/storage math.

## Deliberately NOT included (reviewed, rejected)

- League-entries raw capture: only ~15 fields, the un-captured ones are low-value booleans, and missed snapshots are unrecoverable regardless — no retroactive benefit.
- Match timeline endpoint: doubles Match-V5 request cost against the binding 100/120s budget and ~10x storage; revisit only if a gold-graph/build-timing feature actually lands.

## Verification

Real Postgres 16 container: double insert → 1 row; JSONB field extraction by puuid matches source; all three pre-filter states behave (both tables / stats-only / neither, incl. the duo second-row case). `py_compile` + ruff clean.

Storage: ~25–45 KB/match after TOAST ≈ 0.3 GB for the current 9k matches.