### PR TITLE
DRY: shared leaderboard helpers for the solo + Ranked 5s boards

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -6,7 +6,7 @@ from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
 from pantheon.utils.exceptions import ServerError
-from utils import db
+from utils import db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.rank_sorting_class import Ranker
 from utils.riot_client import get_league_entries
@@ -20,6 +20,9 @@ from utils.riot_stats import fetch_recent_kd
 # in this channel. The ping rearms after they win again.
 STREAK_PING_CHANNEL = 667751882260742167  # #general
 STREAK_THRESHOLD = 7
+
+# league_history.queue tag for this board's rows (also the column default).
+SOLO_QUEUE = "RANKED_SOLO_5x5"
 
 
 class FetchFromRiot(commands.Cog):
@@ -97,82 +100,23 @@ class FetchFromRiot(commands.Cog):
         return
 
     async def get_last_five_games(self, puuid):
-        # Older history rows are keyed by the legacy encrypted summoner ID
-        # (league_players.leagueId, ~47 chars), newer rows by the real
-        # puuid (~78 chars). Query both so legacy-tracked players still
-        # surface their game history. Solo queue only — Ranked 5s rows
-        # share the table and would corrupt the win/loss diffs.
-        rows = await db.fetchall(
-            "SELECT wins, losses FROM league_history "
-            "WHERE puuid IN ("
-            "    SELECT leagueId FROM league_players WHERE puuid = %s"
-            "    UNION"
-            "    SELECT puuid    FROM league_players WHERE puuid = %s"
-            ") "
-            "AND queue = 'RANKED_SOLO_5x5' "
-            "AND wins IS NOT NULL AND losses IS NOT NULL "
-            "ORDER BY id DESC LIMIT 6",
-            (puuid, puuid),
-        )
-        if not rows:
-            return ""
-        sequence = []
-        for i in range(len(rows) - 1):
-            newer_w, newer_l = rows[i]
-            older_w, older_l = rows[i + 1]
-            delta_w = max(newer_w - older_w, 0)
-            delta_l = max(newer_l - older_l, 0)
-            sequence.extend(["\U0001f7e9"] * delta_w + ["\U0001f7e5"] * delta_l)
-        # Implicit (0,0) baseline for brand-new accounts: only valid when the
-        # oldest fetched row's cumulative game count is small.
-        oldest_w, oldest_l = rows[-1]
-        if oldest_w + oldest_l <= 5:
-            sequence.extend(["\U0001f7e9"] * oldest_w + ["\U0001f7e5"] * oldest_l)
-        # Cap to last 5; reverse so newest game is on the right.
-        return "".join(reversed(sequence[:5]))
+        # legacy_dual_key: pre-2024 history rows are keyed by the legacy
+        # encrypted summoner ID (league_players.leagueId, ~47 chars), newer
+        # rows by the real puuid (~78 chars).
+        rows = await leaderboard.fetch_history_wl(puuid, SOLO_QUEUE, 6, legacy_dual_key=True)
+        return leaderboard.build_last_five(rows)
 
     async def get_recent_streak(self, puuid):
         """Return the count of consecutive losses ending at the most recent game.
 
-        Looks at the last ~15 history rows for the player (covering both
-        legacy-summonerId-keyed and real-puuid-keyed rows), reconstructs the
-        outcome sequence (newest first), and counts leading losses. Returns
-        0 if the most recent game was a win or there's no history.
-
-        Within a multi-game-per-cycle diff we don't know the in-cycle order;
-        we conservatively place wins BEFORE losses in the sequence, which
-        means a (1W, 2L) diff at the head reports a 0-game loss streak even
-        if losses could have come last. False-negatives over false-positives
-        for the ping.
+        Looks at the last ~15 history rows (both legacy-summonerId-keyed
+        and real-puuid-keyed). Returns 0 if the most recent game was a win
+        or there's no history — see leaderboard.count_leading_losses for
+        the in-cycle ordering caveat (false-negatives over false-positives
+        for the ping).
         """
-        rows = await db.fetchall(
-            "SELECT wins, losses FROM league_history "
-            "WHERE puuid IN ("
-            "    SELECT leagueId FROM league_players WHERE puuid = %s"
-            "    UNION"
-            "    SELECT puuid    FROM league_players WHERE puuid = %s"
-            ") "
-            "AND queue = 'RANKED_SOLO_5x5' "
-            "AND wins IS NOT NULL AND losses IS NOT NULL "
-            "ORDER BY id DESC LIMIT 15",
-            (puuid, puuid),
-        )
-        if len(rows) < 2:
-            return 0
-        sequence: list[str] = []
-        for i in range(len(rows) - 1):
-            newer_w, newer_l = rows[i]
-            older_w, older_l = rows[i + 1]
-            delta_w = max(newer_w - older_w, 0)
-            delta_l = max(newer_l - older_l, 0)
-            sequence.extend(["W"] * delta_w + ["L"] * delta_l)
-        streak = 0
-        for outcome in sequence:
-            if outcome == "L":
-                streak += 1
-            else:
-                break
-        return streak
+        rows = await leaderboard.fetch_history_wl(puuid, SOLO_QUEUE, 15, legacy_dual_key=True)
+        return leaderboard.count_leading_losses(rows)
 
     async def send_streak_ping(self, user_id: int, streak: int, puuid: str) -> None:
         channel = self.bot.get_channel(STREAK_PING_CHANNEL)
@@ -273,93 +217,19 @@ class FetchFromRiot(commands.Cog):
             #                         key=lambda d: d["WinRate"],
             #                         reverse=True)
 
-            output_list = []
-            current_positions: dict[str, int] = {}
-            for index, posting in enumerate(sorted_results):
-                current_pos = index + 1
-                current_positions[posting["summonerName"]] = current_pos
-                prev_pos = self.previous_positions.get(posting["summonerName"])
-                # \U00002B06\U0000FE0F = ⬆️, \U00002B07\U0000FE0F = ⬇️
-                if prev_pos is None or prev_pos == current_pos:
-                    position_arrow = ""
-                elif current_pos < prev_pos:
-                    position_arrow = "\U00002b06\U0000fe0f "
-                else:
-                    position_arrow = "\U00002b07\U0000fe0f "
-
-                updated_flag = (
-                    " \U0001f6a9" if posting["summonerName"] in self.last_updated_by else ""
-                )
-                last_five = await self.get_last_five_games(posting["puuid"])
-                last_five_line = f"Last 5: {last_five}\n" if last_five else ""
-                # Apex tiers have no real division (league-v4 reports rank "I").
-                if posting["tier"].title() in ("Master", "Grandmaster", "Challenger"):
-                    post = (
-                        position_arrow
-                        + str(index + 1)
-                        + ". "
-                        + posting["summonerName"]
-                        + f" - <@{posting['user_id']}>"
-                        + updated_flag
-                        + "\n"
-                        + "Rank: "
-                        + posting["tier"].title()
-                        + " "
-                        + str(posting["leaguePoints"])
-                        + "lp"
-                        + "\n"
-                        + "Played: "
-                        + str(posting["GamesPlayed"])
-                        + " with a "
-                        + str("{:.2f}".format(posting["WinRate"]))
-                        + "% winrate"
-                        + "\n"
-                        + last_five_line
-                    )
-                else:
-                    post = (
-                        position_arrow
-                        + str(index + 1)
-                        + ". "
-                        + posting["summonerName"]
-                        + f" - <@{posting['user_id']}>"
-                        + updated_flag
-                        + "\n"
-                        + "Rank: "
-                        + posting["tier"].title()
-                        + " "
-                        + posting["rank"]
-                        + " "
-                        + str(posting["leaguePoints"])
-                        + "lp"
-                        + "\n"
-                        + "Played: "
-                        + str(posting["GamesPlayed"])
-                        + " games with a "
-                        + str("{:.2f}".format(posting["WinRate"]))
-                        + "% winrate"
-                        + "\n"
-                        + last_five_line
-                    )
-                output_list.append(post)
-
-            # Remember positions for next cycle's arrow comparisons.
-            self.previous_positions = current_positions
+            # apex_omits_games_word: this board's apex entries have always
+            # read "Played: N with a ..." — see utils/leaderboard.py.
+            # previous_positions feeds next cycle's arrow comparisons.
+            output_list, self.previous_positions = await leaderboard.render_board_entries(
+                sorted_results,
+                self.previous_positions,
+                self.last_updated_by,
+                self.get_last_five_games,
+                apex_omits_games_word=True,
+            )
 
             paste = self.bot.get_channel(919981835428179988)
-            try:
-                async for message in paste.history():
-                    await message.delete()
-            except discord.errors.Forbidden:
-                self.bot.logging.warning("Missing permissions to delete messages, skipping cleanup")
-
-            if len(output_list) != 0:
-                to_send = "\n".join(output_list)
-                await paste.send(
-                    to_send,
-                    silent=True,
-                    allowed_mentions=discord.AllowedMentions.none(),
-                )
+            await leaderboard.wipe_and_post(paste, "\n".join(output_list), self.bot.logging)
 
         # Watchdog input: heartbeat cog reads this and reloads us if it
         # goes stale (typically because a Gateway disconnect left the
@@ -445,17 +315,12 @@ class FetchFromRiot(commands.Cog):
 
     # Needs updating to grab last match from the table
     async def update_table(self, user, user_stats_dict):
+        # Keeps this board's historical logging/except shape (including the
+        # harmless "Exception as list index out of range" info line on a
+        # player's first-ever insert) around the shared history helpers.
         try:
             self.bot.logging.info(f"updating table, logging {user_stats_dict}")
-            # Explicit columns (not SELECT *) so the new `queue` column can't
-            # shift the wins/losses positions; solo-queue rows only so a
-            # Ranked 5s snapshot never masks a pending solo insert.
-            last_values = await db.fetchall(
-                "SELECT wins, losses FROM league_history "
-                "WHERE puuid = %s AND queue = 'RANKED_SOLO_5x5' "
-                "ORDER BY id DESC LIMIT 1",
-                (user_stats_dict["puuid"],),
-            )
+            last_values = await leaderboard.latest_history_wl(user_stats_dict["puuid"], SOLO_QUEUE)
         except Exception as e:
             self.bot.logging.error(f"Failed to update table with error: {e}")
             return
@@ -468,20 +333,7 @@ class FetchFromRiot(commands.Cog):
         except Exception as e:
             self.bot.logging.info(f"Exception as {e}")
 
-        # `queue` is omitted — the column defaults to RANKED_SOLO_5x5.
-        # leaguePoints arrives as int from Riot; keep it int (psycopg will
-        # not cast str -> INTEGER the way sqlite silently did).
-        await db.execute(
-            "INSERT INTO league_history (puuid, lp, division, tier, wins, losses) VALUES (%s, %s, %s, %s, %s, %s)",
-            (
-                user_stats_dict["puuid"],
-                int(user_stats_dict["leaguePoints"]),
-                user_stats_dict["rank"],
-                user_stats_dict["tier"],
-                user_stats_dict["wins"],
-                user_stats_dict["losses"],
-            ),
-        )
+        await leaderboard.insert_history_snapshot(user_stats_dict, SOLO_QUEUE)
         return
 
 

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -1,6 +1,7 @@
 """Leaderboard for the 2026 limited-test "Ranked 5s" weekend queue.
 
-Mirrors cogs/league_table_updater.py (the solo-queue board) but:
+Shares its rendering/history core with the solo-queue board
+(cogs/league_table_updater.py) via utils/leaderboard.py, but:
   - only polls while the queue window is live (utils/queue_windows.py) —
     Fri/Sat/Sun 20:00-01:00 Europe/Paris plus a 2h post-close tail;
   - writes/reads league_history rows tagged queue = 'RANKED_5S';
@@ -27,7 +28,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
-from utils import db
+from utils import db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.queue_windows import is_ranked5s_open, is_ranked5s_tracking, next_window_open
 from utils.rank_sorting_class import Ranker
@@ -173,58 +174,17 @@ class Ranked5sBoard(commands.Cog):
         encrypted-summoner-ID dual-key union the solo board needs for its
         pre-2024 rows does not apply here, so plain puuid equality is enough.
         """
-        last = await db.fetchone(
-            "SELECT wins, losses FROM league_history "
-            "WHERE puuid = %s AND queue = %s "
-            "ORDER BY id DESC LIMIT 1",
-            (entry["puuid"], QUEUE_KEY),
-        )
-        if last is not None and last == (entry["wins"], entry["losses"]):
-            return
-        self.bot.logging.info(
-            f"5s history insert for {entry['summonerName']}: "
-            f"{entry['tier']} {entry['rank']} {entry['leaguePoints']}lp "
-            f"{entry['wins']}W/{entry['losses']}L"
-        )
-        await db.execute(
-            "INSERT INTO league_history (puuid, lp, division, tier, wins, losses, queue) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-            (
-                entry["puuid"],
-                int(entry["leaguePoints"]),
-                entry["rank"],
-                entry["tier"],
-                int(entry["wins"]),
-                int(entry["losses"]),
-                QUEUE_KEY,
-            ),
-        )
+        if await leaderboard.record_history_snapshot(entry, QUEUE_KEY):
+            self.bot.logging.info(
+                f"5s history insert for {entry['summonerName']}: "
+                f"{entry['tier']} {entry['rank']} {entry['leaguePoints']}lp "
+                f"{entry['wins']}W/{entry['losses']}L"
+            )
 
     async def _get_last_five_games(self, puuid: str) -> str:
         """Green/red squares for the player's last 5 games on the 5s ladder."""
-        rows = await db.fetchall(
-            "SELECT wins, losses FROM league_history "
-            "WHERE puuid = %s AND queue = %s "
-            "AND wins IS NOT NULL AND losses IS NOT NULL "
-            "ORDER BY id DESC LIMIT 6",
-            (puuid, QUEUE_KEY),
-        )
-        if not rows:
-            return ""
-        sequence = []
-        for i in range(len(rows) - 1):
-            newer_w, newer_l = rows[i]
-            older_w, older_l = rows[i + 1]
-            delta_w = max(newer_w - older_w, 0)
-            delta_l = max(newer_l - older_l, 0)
-            sequence.extend(["\U0001f7e9"] * delta_w + ["\U0001f7e5"] * delta_l)
-        # Implicit (0,0) baseline — always valid on this ladder while the
-        # oldest stored row is within the first few games of the test.
-        oldest_w, oldest_l = rows[-1]
-        if oldest_w + oldest_l <= 5:
-            sequence.extend(["\U0001f7e9"] * oldest_w + ["\U0001f7e5"] * oldest_l)
-        # Cap to last 5; reverse so the newest game is on the right.
-        return "".join(reversed(sequence[:5]))
+        rows = await leaderboard.fetch_history_wl(puuid, QUEUE_KEY, 6)
+        return leaderboard.build_last_five(rows)
 
     # ---------------------------------------------------------------- channel
 
@@ -262,54 +222,15 @@ class Ranked5sBoard(commands.Cog):
             else:
                 header += " (queue closed — test window over)"
 
-        output_list = [header]
-        current_positions: dict[str, int] = {}
-        for index, posting in enumerate(sorted_results):
-            current_pos = index + 1
-            current_positions[posting["summonerName"]] = current_pos
-            prev_pos = self.previous_positions.get(posting["summonerName"])
-            # \U00002B06\U0000FE0F = up arrow, \U00002B07\U0000FE0F = down arrow
-            if prev_pos is None or prev_pos == current_pos:
-                position_arrow = ""
-            elif current_pos < prev_pos:
-                position_arrow = "\U00002b06\U0000fe0f "
-            else:
-                position_arrow = "\U00002b07\U0000fe0f "
-
-            updated_flag = " \U0001f6a9" if posting["summonerName"] in self.last_updated_by else ""
-            last_five = await self._get_last_five_games(posting["puuid"])
-            last_five_line = f"Last 5: {last_five}\n" if last_five else ""
-            # Apex tiers have no real division (league-v4 reports rank "I").
-            if posting["tier"].title() in ("Master", "Grandmaster", "Challenger"):
-                rank_line = f"Rank: {posting['tier'].title()} {posting['leaguePoints']}lp"
-            else:
-                rank_line = (
-                    f"Rank: {posting['tier'].title()} {posting['rank']} "
-                    f"{posting['leaguePoints']}lp"
-                )
-            post = (
-                position_arrow
-                + str(current_pos)
-                + ". "
-                + posting["summonerName"]
-                + f" - <@{posting['user_id']}>"
-                + updated_flag
-                + "\n"
-                + rank_line
-                + "\n"
-                + "Played: "
-                + str(posting["GamesPlayed"])
-                + " games with a "
-                + str("{:.2f}".format(posting["WinRate"]))
-                + "% winrate"
-                + "\n"
-                + last_five_line
-            )
-            output_list.append(post)
-
-        # Remember positions for next cycle's arrow comparisons.
-        self.previous_positions = current_positions
-        return "\n".join(output_list)
+        # previous_positions feeds next cycle's arrow comparisons. Unlike
+        # the solo board, apex entries here keep the " games " wording.
+        entries, self.previous_positions = await leaderboard.render_board_entries(
+            sorted_results,
+            self.previous_positions,
+            self.last_updated_by,
+            self._get_last_five_games,
+        )
+        return "\n".join([header] + entries)
 
     # ------------------------------------------------------------------- loop
 
@@ -344,19 +265,8 @@ class Ranked5sBoard(commands.Cog):
         self.bot.logging.info("Posting Ranked 5s board")
         sorted_results = sorted(ranked_dict.values(), key=lambda d: d["sorted_rank"], reverse=True)
         to_send = await self._render_board(sorted_results)
-
-        try:
-            async for message in channel.history():
-                await message.delete()
-        except discord.errors.Forbidden:
-            self.bot.logging.warning("Missing permissions to delete messages, skipping cleanup")
-
         # Ping-free board: silent send, no mentions resolved.
-        await channel.send(
-            to_send,
-            silent=True,
-            allowed_mentions=discord.AllowedMentions.none(),
-        )
+        await leaderboard.wipe_and_post(channel, to_send, self.bot.logging)
 
     @tasks.loop(seconds=120)
     async def post_ranks_5s(self):

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -1,0 +1,264 @@
+"""Shared core for the ranked leaderboard cogs.
+
+Both boards — solo/duo (cogs/league_table_updater.py, class FetchFromRiot)
+and the weekend Ranked 5s ladder (cogs/ranked5s_table_updater.py, class
+Ranked5sBoard) — post the same entry format and record the same
+league_history snapshots. They differ only in which ``league_history.queue``
+tag they read/write plus thin cog-specific behaviour (streak ping,
+min-games filter, window gating, channel discovery) that stays in the cogs.
+Everything queue-agnostic lives here: data in, strings/rows out.
+
+league_history key note: solo-queue rows written pre-2024 are keyed by the
+legacy encrypted summoner ID (league_players.leagueId) instead of the real
+puuid, so solo reads must union both keys (``legacy_dual_key=True``).
+Ranked 5s rows are always puuid-keyed.
+"""
+
+import discord
+from utils import db
+
+APEX_TIERS = ("Master", "Grandmaster", "Challenger")
+
+WIN_SQUARE = "\U0001f7e9"  # green square
+LOSS_SQUARE = "\U0001f7e5"  # red square
+
+
+# ------------------------------------------------------------------ history
+
+
+async def fetch_history_wl(
+    puuid: str, queue: str, limit: int, *, legacy_dual_key: bool = False
+) -> list[tuple]:
+    """Newest-first cumulative (wins, losses) rows for one player + queue.
+
+    ``legacy_dual_key`` additionally matches rows keyed by the legacy
+    encrypted summoner ID (league_players.leagueId) — required for solo
+    reads so legacy-tracked players still surface their history; pointless
+    for Ranked 5s. Filtering on ``queue`` matters either way: both boards
+    share the table, and cross-queue rows would corrupt the win/loss diffs.
+    """
+    if legacy_dual_key:
+        return await db.fetchall(
+            "SELECT wins, losses FROM league_history "
+            "WHERE puuid IN ("
+            "    SELECT leagueId FROM league_players WHERE puuid = %s"
+            "    UNION"
+            "    SELECT puuid    FROM league_players WHERE puuid = %s"
+            ") "
+            "AND queue = %s "
+            "AND wins IS NOT NULL AND losses IS NOT NULL "
+            "ORDER BY id DESC LIMIT %s",
+            (puuid, puuid, queue, limit),
+        )
+    return await db.fetchall(
+        "SELECT wins, losses FROM league_history "
+        "WHERE puuid = %s AND queue = %s "
+        "AND wins IS NOT NULL AND losses IS NOT NULL "
+        "ORDER BY id DESC LIMIT %s",
+        (puuid, queue, limit),
+    )
+
+
+async def latest_history_wl(puuid: str, queue: str) -> list[tuple]:
+    """``[(wins, losses)]`` of the newest snapshot, ``[]`` if none exists.
+
+    Unlike :func:`fetch_history_wl` this does NOT filter NULL wins/losses —
+    the snapshot writer must see a NULL-w/l row as "latest" rather than skip
+    past it. Explicit columns (not SELECT *) so the ``queue`` column can't
+    shift the wins/losses positions; queue-scoped so a Ranked 5s snapshot
+    never masks a pending solo insert (and vice versa).
+    """
+    return await db.fetchall(
+        "SELECT wins, losses FROM league_history "
+        "WHERE puuid = %s AND queue = %s "
+        "ORDER BY id DESC LIMIT 1",
+        (puuid, queue),
+    )
+
+
+async def insert_history_snapshot(entry: dict, queue: str) -> None:
+    """INSERT one league_history snapshot row tagged with ``queue``.
+
+    leaguePoints arrives as int from Riot; keep it int (psycopg will not
+    cast str -> INTEGER the way sqlite silently did).
+    """
+    await db.execute(
+        "INSERT INTO league_history (puuid, lp, division, tier, wins, losses, queue) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+        (
+            entry["puuid"],
+            int(entry["leaguePoints"]),
+            entry["rank"],
+            entry["tier"],
+            int(entry["wins"]),
+            int(entry["losses"]),
+            queue,
+        ),
+    )
+
+
+async def record_history_snapshot(entry: dict, queue: str) -> bool:
+    """SELECT latest -> skip if unchanged -> INSERT. True if a row was written."""
+    last = await latest_history_wl(entry["puuid"], queue)
+    if last and last[0] == (entry["wins"], entry["losses"]):
+        return False
+    await insert_history_snapshot(entry, queue)
+    return True
+
+
+# -------------------------------------------------------- outcome sequences
+
+
+def _delta_outcomes(rows: list[tuple], win_token: str, loss_token: str) -> list[str]:
+    """Per-game outcome tokens from newest-first cumulative (w, l) rows.
+
+    Within one multi-game diff the true order is unknown; wins are placed
+    BEFORE losses. The max(..., 0) clamps guard against season resets
+    driving a diff negative.
+    """
+    sequence: list[str] = []
+    for i in range(len(rows) - 1):
+        newer_w, newer_l = rows[i]
+        older_w, older_l = rows[i + 1]
+        delta_w = max(newer_w - older_w, 0)
+        delta_l = max(newer_l - older_l, 0)
+        sequence.extend([win_token] * delta_w + [loss_token] * delta_l)
+    return sequence
+
+
+def build_last_five(rows: list[tuple]) -> str:
+    """Green/red squares for the last <=5 games, newest on the right.
+
+    ``rows`` are newest-first cumulative (wins, losses) snapshots
+    (see :func:`fetch_history_wl` with limit 6).
+    """
+    if not rows:
+        return ""
+    sequence = _delta_outcomes(rows, WIN_SQUARE, LOSS_SQUARE)
+    # Implicit (0,0) baseline for brand-new accounts: only valid when the
+    # oldest fetched row's cumulative game count is small.
+    oldest_w, oldest_l = rows[-1]
+    if oldest_w + oldest_l <= 5:
+        sequence.extend([WIN_SQUARE] * oldest_w + [LOSS_SQUARE] * oldest_l)
+    # Cap to last 5; reverse so the newest game is on the right.
+    return "".join(reversed(sequence[:5]))
+
+
+def count_leading_losses(rows: list[tuple]) -> int:
+    """Consecutive losses ending at the most recent game; 0 on a fresh win.
+
+    Because :func:`_delta_outcomes` places wins before losses inside one
+    diff, a mixed diff at the head reports 0 — false-negatives over
+    false-positives (this feeds the solo board's loss-streak ping).
+    """
+    if len(rows) < 2:
+        return 0
+    streak = 0
+    for outcome in _delta_outcomes(rows, "W", "L"):
+        if outcome == "L":
+            streak += 1
+        else:
+            break
+    return streak
+
+
+# ------------------------------------------------------------------- render
+
+
+def render_board_entry(
+    posting: dict,
+    position: int,
+    previous_position: int | None,
+    updated: bool,
+    last_five: str,
+    *,
+    apex_omits_games_word: bool = False,
+) -> str:
+    """One board entry: name/arrow/flag line, rank line, played line, last-5.
+
+    ``apex_omits_games_word`` reproduces the solo board's long-standing
+    quirk where apex entries read "Played: N with a ..." (no "games") while
+    every other entry on either board reads "N games with a".
+    """
+    # \U00002B06\U0000FE0F = up arrow, \U00002B07\U0000FE0F = down arrow
+    if previous_position is None or previous_position == position:
+        position_arrow = ""
+    elif position < previous_position:
+        position_arrow = "\U00002b06\U0000fe0f "
+    else:
+        position_arrow = "\U00002b07\U0000fe0f "
+    updated_flag = " \U0001f6a9" if updated else ""  # triangular flag
+    last_five_line = f"Last 5: {last_five}\n" if last_five else ""
+
+    tier = posting["tier"].title()
+    is_apex = tier in APEX_TIERS
+    # Apex tiers have no real division (league-v4 reports rank "I").
+    if is_apex:
+        rank_line = f"Rank: {tier} {posting['leaguePoints']}lp"
+    else:
+        rank_line = f"Rank: {tier} {posting['rank']} {posting['leaguePoints']}lp"
+    games_word = "" if is_apex and apex_omits_games_word else " games"
+    return (
+        f"{position_arrow}{position}. {posting['summonerName']} - <@{posting['user_id']}>"
+        f"{updated_flag}\n"
+        f"{rank_line}\n"
+        f"Played: {posting['GamesPlayed']}{games_word} with a {posting['WinRate']:.2f}% winrate\n"
+        f"{last_five_line}"
+    )
+
+
+async def render_board_entries(
+    sorted_results: list[dict],
+    previous_positions: dict[str, int],
+    last_updated_by: list[str],
+    fetch_last_five,
+    *,
+    apex_omits_games_word: bool = False,
+) -> tuple[list[str], dict[str, int]]:
+    """Render every entry of an already-sorted board.
+
+    Returns ``(entry_strings, current_positions)`` — the caller stores
+    ``current_positions`` for the next cycle's arrow comparisons.
+    ``fetch_last_five`` is an async ``puuid -> squares-string`` callable so
+    each cog keeps its own history scoping (queue tag / legacy dual key).
+    """
+    output_list: list[str] = []
+    current_positions: dict[str, int] = {}
+    for index, posting in enumerate(sorted_results):
+        position = index + 1
+        name = posting["summonerName"]
+        current_positions[name] = position
+        output_list.append(
+            render_board_entry(
+                posting,
+                position,
+                previous_positions.get(name),
+                name in last_updated_by,
+                await fetch_last_five(posting["puuid"]),
+                apex_omits_games_word=apex_omits_games_word,
+            )
+        )
+    return output_list, current_positions
+
+
+# ------------------------------------------------------------------ posting
+
+
+async def wipe_and_post(channel, content: str, log) -> None:
+    """Delete the channel's message history, then silently post ``content``.
+
+    Boards are ping-free: silent send + no mentions resolved. Empty
+    ``content`` still wipes but posts nothing (solo board with an empty
+    entry list).
+    """
+    try:
+        async for message in channel.history():
+            await message.delete()
+    except discord.errors.Forbidden:
+        log.warning("Missing permissions to delete messages, skipping cleanup")
+    if content:
+        await channel.send(
+            content,
+            silent=True,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )


### PR DESCRIPTION
> [!NOTE]
> Stacked on #58. Sibling of #59/#60 (no file overlap — merge in any order after #58).

The two board cogs duplicated the last-five delta walk (three copies, counting the streak counter), the history snapshot dedupe/insert, the per-entry render block, and the wipe-and-post routine. All extracted into `Bot/utils/leaderboard.py`, queue-parameterized; the cogs keep only what genuinely differs (solo: streak ping, min-games filter, name re-sync; 5s: window gating, queueType discovery, bot_config channel).

**Behavior-preserving, verified byte-for-byte**: render output asserted against hand-derived pre-refactor strings; last-five + streak results cross-checked against verbatim copies of the original implementations for all 21 migrated players on a real Postgres (49/49 checks green).

Net **−109 lines** (~330 deleted from the cogs). Two quirks preserved deliberately and flagged for a future call rather than silently changed:
- solo board's apex-tier line says "Played: N with a X% winrate" (missing "games") — one flag flips it to match everything else;
- solo `update_table`'s vestigial info-log on a player's first-ever insert.