### PR TITLE
Config module, pantheon removal, /kda off the API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env and fill in. Read via Bot/utils/config.py — add new
+# config there, not as scattered os.environ.get calls.
+
+# Discord bot token
+token=
+
+# Riot API key (https://developer.riotgames.com). Optional for DB-only dev.
+riot_key=
+
+# Discord server (guild) id the bot lives in
+guild_id=
+
+# Postgres DSN. Prod: the chomage-db LXC. Local dev:
+#   docker run -d -e POSTGRES_USER=chomage -e POSTGRES_PASSWORD=chomage \
+#     -e POSTGRES_DB=chomage -p 5432:5432 postgres:16-alpine
+# then: postgresql://chomage:chomage@localhost:5432/chomage
+DATABASE_URL=
+
+# Optional: pin the Ranked 5s league-v4 queueType once discovered
+# (see docs/riot-api-reference.md).
+# ranked5s_queue_type=

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -5,11 +5,10 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
-from pantheon.utils.exceptions import ServerError
 from utils import db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.rank_sorting_class import Ranker
-from utils.riot_client import get_league_entries
+from utils.riot_client import get_account_by_puuid, get_league_entries
 from utils.riot_stats import fetch_recent_kd
 
 # Want to fetch ranks to post from the database
@@ -91,12 +90,10 @@ class FetchFromRiot(commands.Cog):
                 FROM league_players
                     LEFT JOIN users ON user_id = discord_user_id"""
         )
-        # Fetch current ranks and store them in a dict with updated values
-        try:
-            self.ranked_dict = await self.fetch_users_rank(rows)
-        except ServerError as exc:
-            self.bot.logging.error(f"Error of: {exc}, trying again in 60 seconds")
-            await asyncio.sleep(60)
+        # Fetch current ranks and store them in a dict with updated values.
+        # Per-player API failures are handled inside fetch_users_rank
+        # (riot_client returns None rather than raising).
+        self.ranked_dict = await self.fetch_users_rank(rows)
         return
 
     async def get_last_five_games(self, puuid):
@@ -155,7 +152,10 @@ class FetchFromRiot(commands.Cog):
             return
         puuid, stored_name = row
 
-        name = (await self.bot.lolapi.get_account_by_puuId(puuid))["gameName"]
+        account = await get_account_by_puuid(puuid)
+        if account is None:
+            return  # transient account-v1 failure; retry next cycle
+        name = account["gameName"]
 
         if name != stored_name:
             self.bot.logging.info(f"updating {stored_name} to {name}")

--- a/Bot/cogs/league_user_updater.py
+++ b/Bot/cogs/league_user_updater.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from main import MyDiscordBot
 from utils import db
 from utils.autocomplete import DiscordAttachedLeagueNames
+from utils.riot_client import get_account_by_riot_id
 
 
 class LeagueUsers(commands.Cog):
@@ -25,7 +26,13 @@ class LeagueUsers(commands.Cog):
         user: discord.User,
     ):
         # Get PUUID from Account API - this is all we need now
-        puuid = (await self.bot.lolapi.get_account_by_riotId(league_name, tagline))["puuid"]
+        account = await get_account_by_riot_id(league_name, tagline)
+        if account is None:
+            await ctx.response.send_message(
+                f"Couldn't find {league_name}#{tagline} on Riot's account API"
+            )
+            return
+        puuid = account["puuid"]
 
         await db.execute(
             """INSERT INTO league_players (

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -22,13 +22,12 @@ so this loop reuses the solo board's fetches: near-zero extra API spend.
 """
 
 import datetime as dt
-import os
 
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
-from utils import db, leaderboard
+from utils import config, db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.queue_windows import is_ranked5s_open, is_ranked5s_tracking, next_window_open
 from utils.rank_sorting_class import Ranker
@@ -104,7 +103,7 @@ class Ranked5sBoard(commands.Cog):
         be the 5s ladder, and its string is logged (once per process) so
         it can be pinned in .env.
         """
-        pinned = os.environ.get(QUEUE_TYPE_ENV)
+        pinned = config.ranked5s_queue_type()
         for entry in entries:
             queue_type = entry.get("queueType", "")
             if pinned:
@@ -334,7 +333,7 @@ class Ranked5sBoard(commands.Cog):
     )
     async def ranked5s_status(self, ctx: discord.Interaction):
         await ctx.response.defer(ephemeral=True)
-        pinned = os.environ.get(QUEUE_TYPE_ENV)
+        pinned = config.ranked5s_queue_type()
         if pinned:
             queue_type_line = f"queueType: pinned to `{pinned}`"
         elif self._seen_queue_types:

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -5,14 +5,10 @@ import os
 import sys
 
 import discord
-import pantheon
 from discord.ext.commands import Bot
-from dotenv import load_dotenv
-from utils import db
+from utils import config, db
 
-# Load .env from parent directory relative to this file's location
-env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env")
-load_dotenv(env_path)
+# .env loading + every env read lives in utils/config.py.
 
 
 class MyDiscordBot(Bot):
@@ -25,15 +21,15 @@ class MyDiscordBot(Bot):
         super().__init__(command_prefix, intents=intents)
         self.guildid = serverid
 
-        riot_key = os.environ.get("riot_key")
-        # Log API key info (first/last few chars only for security)
+        riot_key = config.riot_api_key()
+        # Log API key info (first/last few chars only for security). All
+        # Riot calls go through utils/riot_client (shared rate budget).
         if riot_key:
             key_preview = f"{riot_key[:10]}...{riot_key[-4:]}" if len(riot_key) > 14 else "***"
             print(f"Riot API Key loaded: {key_preview}")
         else:
             print("WARNING: Riot API Key not found in environment variables!")
 
-        self.lolapi = pantheon.Pantheon("euw1", riot_key, debug=True)
         self.logging: logging.Logger = None
 
     async def setup_hook(self) -> None:
@@ -99,9 +95,7 @@ async def main(my_token: str) -> None:
     await db.apply_schema("./db/setup.postgres.sql")
     print("Database schema applied")
 
-    server_id = int(os.environ.get("guild_id", "0"))
-    if server_id == 0:
-        raise ValueError("guild_id environment variable must be set in .env file")
+    server_id = config.guild_id()
 
     bot = MyDiscordBot(
         command_prefix="!",
@@ -119,10 +113,7 @@ if __name__ == "__main__":
     if sys.platform == "win32":
         # psycopg's async pool can't run on Windows' default ProactorEventLoop.
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    token = os.environ.get("token")
-    if not token:
-        raise ValueError("token env var must be set in .env file")
-    asyncio.run(main(token))
+    asyncio.run(main(config.discord_token()))
 
 #
 # bot.start(token)

--- a/Bot/requirements.txt
+++ b/Bot/requirements.txt
@@ -3,9 +3,7 @@ discord.py
 asyncio
 psycopg[binary]>=3.1
 psycopg-pool
-riotwatcher
 python-dotenv
-pantheon
 matplotlib==3.7
 opencv-python
 numpy<2

--- a/Bot/utils/config.py
+++ b/Bot/utils/config.py
@@ -1,0 +1,61 @@
+"""Central runtime configuration.
+
+Every environment variable the bot reads lives behind a getter here — one
+place to see the whole config surface and one place to add the next value.
+Loads the repo-root ``.env`` on import (the same file main.py always used),
+so standalone scripts that import any utils module get the same view.
+
+Required values raise :class:`MissingConfigError` with a hint instead of
+falling back to baked-in defaults — no credentials live in code.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+# Bot/utils/config.py -> repo root .env (sits next to docker-compose.yml).
+_ENV_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".env")
+load_dotenv(_ENV_PATH)
+
+
+class MissingConfigError(RuntimeError):
+    """A required env var is absent — the .env is incomplete."""
+
+
+def _require(name: str, hint: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise MissingConfigError(f"{name} is not set — add it to .env ({hint})")
+    return value
+
+
+def database_url() -> str:
+    """Postgres DSN. Prod: the chomage-db LXC; dev: your own container.
+
+    See docs/db-access.md and .env.example — there is deliberately no
+    default with credentials in it.
+    """
+    return _require(
+        "DATABASE_URL",
+        "e.g. postgresql://<user>:<password>@<host>:5432/chomage — see docs/db-access.md",
+    )
+
+
+def discord_token() -> str:
+    return _require("token", "the Discord bot token")
+
+
+def guild_id() -> int:
+    return int(_require("guild_id", "the Discord server id the bot lives in"))
+
+
+def riot_api_key() -> str | None:
+    """Riot API key; None is tolerated so DB-only dev setups can run."""
+    return os.environ.get("riot_key")
+
+
+def ranked5s_queue_type() -> str | None:
+    """Pinned league-v4 queueType for Ranked 5s (unset = auto-discover)."""
+    return os.environ.get("ranked5s_queue_type")

--- a/Bot/utils/db.py
+++ b/Bot/utils/db.py
@@ -4,8 +4,8 @@ Every DB touch in the codebase goes through this module so there is exactly
 one pool, one DSN source, and one place to change if the database moves
 (e.g. the planned RDS migration).
 
-Connection string comes from the ``DATABASE_URL`` env var; the default
-matches the ``db`` service in docker-compose.yml.
+Connection string comes from ``DATABASE_URL`` via utils/config.py —
+required, no baked-in credential fallback.
 
 Postgres notes for query authors:
   - placeholders are ``%s`` (psycopg3), not sqlite's ``?``
@@ -16,10 +16,10 @@ Postgres notes for query authors:
 
 from __future__ import annotations
 
-import os
 from contextlib import asynccontextmanager
 
 from psycopg_pool import AsyncConnectionPool
+from utils import config
 
 # Survive auto_reload's importlib.reload of utils modules: re-executing this
 # module body must not orphan a live pool (leaked connections would pile up
@@ -28,13 +28,7 @@ _pool: AsyncConnectionPool | None = globals().get("_pool")
 
 
 def dsn() -> str:
-    # Prod sets DATABASE_URL in .env, pointing at the dedicated Postgres
-    # LXC on the Proxmox host. The localhost fallback only serves local
-    # development against a throwaway Postgres.
-    return os.environ.get(
-        "DATABASE_URL",
-        "postgresql://chomage:chomage@localhost:5432/chomage",
-    )
+    return config.database_url()
 
 
 async def get_pool() -> AsyncConnectionPool:

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -18,18 +18,21 @@ Public API:
   - :func:`get_league_entries` — solo/duo/flex ranked entries for a puuid.
   - :func:`get_match_ids` — recent match IDs for a puuid (Match-V5).
   - :func:`get_match` — full match details by match ID (Match-V5).
+  - :func:`get_account_by_riot_id` / :func:`get_account_by_puuid` —
+    account-v1 lookups (formerly via pantheon, which bypassed this budget).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import random
 import time
 from collections import deque
+from urllib.parse import quote
 
 import aiohttp
+from utils import config
 
 # (max_requests, window_seconds)
 LIMITS: list[tuple[int, float]] = [
@@ -94,7 +97,7 @@ async def _get_json(url: str, params: dict | None = None) -> tuple[int, list | d
 
     On 429 honours ``Retry-After`` with small jitter and retries internally.
     """
-    riot_key = os.environ.get("riot_key")
+    riot_key = config.riot_api_key()
     if not riot_key:
         log.error("riot_key env var not set")
         return (0, None)
@@ -178,6 +181,31 @@ async def get_match_ids(
 async def get_match(match_id: str) -> dict | None:
     """Full match details by match ID. Match-V5."""
     url = f"{REGION_HOST}/lol/match/v5/matches/{match_id}"
+    status, body = await _get_json(url)
+    if status != 200 or not isinstance(body, dict):
+        return None
+    return body
+
+
+async def get_account_by_riot_id(game_name: str, tag_line: str) -> dict | None:
+    """Account-v1 lookup by Riot ID (gameName#tagLine). Regional host.
+
+    Returns the account dict ({"puuid", "gameName", "tagLine"}) or None on
+    failure / unknown account. Names can contain spaces — path-quoted.
+    """
+    url = (
+        f"{REGION_HOST}/riot/account/v1/accounts/by-riot-id/"
+        f"{quote(game_name, safe='')}/{quote(tag_line, safe='')}"
+    )
+    status, body = await _get_json(url)
+    if status != 200 or not isinstance(body, dict):
+        return None
+    return body
+
+
+async def get_account_by_puuid(puuid: str) -> dict | None:
+    """Account-v1 lookup by puuid (current gameName/tagLine). Regional host."""
+    url = f"{REGION_HOST}/riot/account/v1/accounts/by-puuid/{puuid}"
     status, body = await _get_json(url)
     if status != 200 or not isinstance(body, dict):
         return None

--- a/Bot/utils/riot_stats.py
+++ b/Bot/utils/riot_stats.py
@@ -1,37 +1,26 @@
-from utils.riot_client import get_match, get_match_ids
+from utils import db
+from utils.riot_client import RANKED_SOLO_QUEUE_ID
 
 
 async def fetch_recent_kd(puuid: str, count: int = 20) -> tuple[int, int, int, int, int]:
     """Totals across a player's last N ranked solo/duo matches.
 
-    Returns ``(kills, deaths, assists, wins, games_counted)``. On any API
-    failure returns ``(0, 0, 0, 0, 0)``; callers should treat
+    Returns ``(kills, deaths, assists, wins, games_counted)``; callers treat
     ``games_counted == 0`` as "no data".
 
-    Each call hits Riot's Match-V5 ~N+1 times via the shared rate-limited
-    client. Safe to call concurrently — callers serialise behind the global
-    limiter rather than racing.
+    Reads match_stats instead of Riot — this used to burn ~N+1 Match-V5
+    calls per invocation for numbers the stream already ingests. The 5-min
+    stream means a game finished moments ago may not be counted yet; at
+    N=20 that skews nothing worth an API round-trip.
     """
-    match_ids = await get_match_ids(puuid, count=count)
-    if not match_ids:
-        return (0, 0, 0, 0, 0)
-
-    kills = 0
-    deaths = 0
-    assists = 0
-    wins = 0
-    games = 0
-    for match_id in match_ids:
-        match = await get_match(match_id)
-        if match is None:
-            continue
-        for p in match["info"]["participants"]:
-            if p["puuid"] == puuid:
-                kills += p["kills"]
-                deaths += p["deaths"]
-                assists += p["assists"]
-                wins += 1 if p["win"] else 0
-                games += 1
-                break
-
-    return (kills, deaths, assists, wins, games)
+    rows = await db.fetchall(
+        "SELECT kills, deaths, assists, win FROM match_stats "
+        "WHERE puuid = %s AND queue_id = %s "
+        "ORDER BY game_start DESC LIMIT %s",
+        (puuid, RANKED_SOLO_QUEUE_ID, count),
+    )
+    kills = sum(row[0] for row in rows)
+    deaths = sum(row[1] for row in rows)
+    assists = sum(row[2] for row in rows)
+    wins = sum(1 for row in rows if row[3])
+    return (kills, deaths, assists, wins, len(rows))

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -48,8 +48,9 @@ BATCH_SIZE = 1000
 # wrongly resolve to /Bot/Bot/db/... . /scripts/..  ->  /Bot/db/... works.
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_SQLITE = os.path.join(_REPO_ROOT, "Bot", "db", "database.sqlite")
-# Fallback mirrors utils/db.dsn(); prod passes the Postgres LXC's URL.
-DEFAULT_DSN = os.environ.get("DATABASE_URL", "postgresql://chomage:chomage@localhost:5432/chomage")
+# DSN comes from --database-url or the DATABASE_URL env var — like
+# utils/config.py, no baked-in credential fallback.
+DEFAULT_DSN = os.environ.get("DATABASE_URL")
 DEFAULT_SCHEMA = os.path.join(_REPO_ROOT, "Bot", "db", "setup.postgres.sql")
 
 # (table, identity column to preserve or None, timestamp columns)
@@ -163,7 +164,7 @@ def main() -> int:
     parser.add_argument(
         "--database-url",
         default=DEFAULT_DSN,
-        help="Postgres DSN (default: DATABASE_URL env var, else localhost test DSN)",
+        help="Postgres DSN (default: the DATABASE_URL env var; required one way or the other)",
     )
     parser.add_argument(
         "--apply-schema",
@@ -172,6 +173,9 @@ def main() -> int:
         help="schema file applied (idempotently) before copying",
     )
     args = parser.parse_args()
+
+    if not args.database_url:
+        parser.error("no DSN: pass --database-url or set the DATABASE_URL env var")
 
     if not os.path.isfile(args.sqlite):
         print(f"sqlite file not found: {args.sqlite}", file=sys.stderr)


### PR DESCRIPTION
> [!NOTE]
> Stacked on #61 (it edits the refactored cogs) — merge #61 first. Sibling of #59/#60 otherwise.

Three follow-ups William asked for, one small commit each:

1. **`utils/config.py`** — central config: owns `.env` loading and every env read (`DATABASE_URL`, `token`, `riot_key`, `guild_id`, `ranked5s_queue_type`). Adding the next config value = one getter here, not scattered `os.environ.get`s. Required values raise a helpful `MissingConfigError`; **the `chomage:chomage@localhost` DSN fallbacks are gone from code** (utils/db + migration script). `.env.example` documents the full surface.
2. **pantheon removed** — its two real uses (`add_player` riot-id lookup, `check_name` puuid lookup) become account-v1 wrappers in `utils/riot_client`, so they finally count against the shared rate budget instead of bypassing it. Bonus fixes: riot-id path quoting (names with spaces), a friendly error for unknown riot ids instead of a KeyError. `pantheon` + `riotwatcher` leave requirements.
3. **`/kda` + streak-ping off the API** — `fetch_recent_kd` was ~21 Match-V5 calls per use (≈1/5 of the entire 2-minute budget) for numbers the stream already stores; now one indexed `match_stats` query with identical signature/output semantics. Only caveat: a game finished within the last ~5 minutes (stream interval) isn't counted yet.

**Verification:** functional checks against a real Postgres 16 (queue filter, LIMIT ordering, empty-history case; config error paths), `py_compile` + ruff clean, `grep pantheon|lolapi|riotwatcher` returns nothing but a docstring history note.