### PR TITLE
Ranked 5s: match-derived fallback board (Riot API exposes no 5s ladder)

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -38,7 +38,12 @@ from discord.ext import commands, tasks
 from psycopg.types.json import Jsonb
 from utils import db
 from utils.loop_restart import restart_loop_later
-from utils.riot_client import get_match, get_match_ids
+from utils.riot_client import (
+    RANKED_5S_QUEUE_ID,
+    RANKED_SOLO_QUEUE_ID,
+    get_match,
+    get_match_ids,
+)
 
 log = logging.getLogger(__name__)
 
@@ -297,55 +302,61 @@ class Backfill(commands.Cog):
         puuid when not given (the stream loop always passes it).
         """
         inserted_total = 0
-        start = 0
-        page_num = 0
         label = name or f"{puuid[:8]}..."
 
-        while True:
-            page_num += 1
-            page_size = PAGE_SIZE if all_history else count
-            ids = await get_match_ids(puuid, count=page_size, start=start)
-            if not ids:
-                break
+        # Track BOTH queues: ranked solo/duo and the weekend Ranked 5s
+        # (710). Riot's league API doesn't expose the 5s ladder yet, so
+        # these match rows are also what the 5s board's fallback standings
+        # are built from. 5s history is tiny (limited-test queue): steady
+        # state costs one extra id-page request per player per pass.
+        for queue in (RANKED_SOLO_QUEUE_ID, RANKED_5S_QUEUE_ID):
+            start = 0
+            page_num = 0
+            while True:
+                page_num += 1
+                page_size = PAGE_SIZE if all_history else count
+                ids = await get_match_ids(puuid, count=page_size, queue=queue, start=start)
+                if not ids:
+                    break
 
-            # Skip a match only if BOTH extracts already exist:
-            #   - a match_stats row FOR THIS puuid. Filtering by match_id
-            #     alone would skip games where this puuid hasn't been
-            #     backfilled yet but another tracked friend already has —
-            #     exactly the "duo's second row" case we need to pick up.
-            #   - a match_raw row (raw payloads are per match, not per
-            #     puuid). Matches ingested before raw capture existed fail
-            #     this leg and get re-fetched once, healing the archive.
-            #     Steady state is unaffected: anything fetched after this
-            #     shipped has both rows, so the 5-min stream stays cheap.
-            placeholders = ",".join(["%s"] * len(ids))
-            existing_rows = await db.fetchall(
-                f"SELECT ms.match_id FROM match_stats ms "
-                f"JOIN match_raw mr ON mr.match_id = ms.match_id "
-                f"WHERE ms.puuid = %s AND ms.match_id IN ({placeholders})",
-                (puuid, *ids),
-            )
-            existing = {row[0] for row in existing_rows}
+                # Skip a match only if BOTH extracts already exist:
+                #   - a match_stats row FOR THIS puuid. Filtering by match_id
+                #     alone would skip games where this puuid hasn't been
+                #     backfilled yet but another tracked friend already has —
+                #     exactly the "duo's second row" case we need to pick up.
+                #   - a match_raw row (raw payloads are per match, not per
+                #     puuid). Matches ingested before raw capture existed fail
+                #     this leg and get re-fetched once, healing the archive.
+                #     Steady state is unaffected: anything fetched after this
+                #     shipped has both rows, so the 5-min stream stays cheap.
+                placeholders = ",".join(["%s"] * len(ids))
+                existing_rows = await db.fetchall(
+                    f"SELECT ms.match_id FROM match_stats ms "
+                    f"JOIN match_raw mr ON mr.match_id = ms.match_id "
+                    f"WHERE ms.puuid = %s AND ms.match_id IN ({placeholders})",
+                    (puuid, *ids),
+                )
+                existing = {row[0] for row in existing_rows}
 
-            to_fetch = [mid for mid in ids if mid not in existing]
-            if to_fetch:
-                page_new = await self._insert_matches(puuid, to_fetch)
-                inserted_total += page_new
-                # Page-level log only when the page actually delivered new rows.
-                # Steady-state stream calls (all matches already in DB) stay quiet.
-                if page_new > 0:
-                    self.bot.logging.info(
-                        f"Backfill: {label} page {page_num} "
-                        f"(start={start}, +{page_new} new, total {inserted_total})"
-                    )
+                to_fetch = [mid for mid in ids if mid not in existing]
+                if to_fetch:
+                    page_new = await self._insert_matches(puuid, to_fetch)
+                    inserted_total += page_new
+                    # Page-level log only when the page actually delivered new
+                    # rows. Steady-state stream calls stay quiet.
+                    if page_new > 0:
+                        self.bot.logging.info(
+                            f"Backfill: {label} queue {queue} page {page_num} "
+                            f"(start={start}, +{page_new} new, total {inserted_total})"
+                        )
 
-            # Stop when Riot returned less than we asked for (end of history)
-            # or when we've satisfied a bounded request.
-            if len(ids) < page_size:
-                break
-            if not all_history:
-                break
-            start += len(ids)
+                # Stop when Riot returned less than we asked for (end of
+                # history) or when we've satisfied a bounded request.
+                if len(ids) < page_size:
+                    break
+                if not all_history:
+                    break
+                start += len(ids)
 
         return inserted_total
 

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -31,7 +31,7 @@ from utils import config, db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.queue_windows import is_ranked5s_open, is_ranked5s_tracking, next_window_open
 from utils.rank_sorting_class import Ranker
-from utils.riot_client import get_league_entries
+from utils.riot_client import RANKED_5S_QUEUE_ID, get_league_entries
 
 # Canonical internal tag for Ranked 5s rows in league_history.queue.
 # Decoupled from whatever league-v4 queueType string Riot ends up using.
@@ -70,6 +70,9 @@ class Ranked5sBoard(commands.Cog):
         # cog instance, not once per loop tick.
         self._seen_queue_types: set[str] = set()
         self._warned_no_channel = False
+        # Last match-derived fallback standings (used while Riot's league
+        # API exposes no 5s ladder) — change detection for reposts.
+        self.previous_fallback: list[dict] = []
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
@@ -249,12 +252,18 @@ class Ranked5sBoard(commands.Cog):
         if updated_users:
             self.last_updated_by = updated_users
 
+        if not ranked_dict:
+            # Riot's league API doesn't expose the Ranked 5s ladder (no
+            # queue enum, no endpoint — verified 2026-07-05), so until it
+            # does, nobody has an entry here and the board falls back to
+            # match-derived standings. The moment Riot ships the ladder,
+            # ranked_dict fills and this path retires itself.
+            await self._post_fallback_board(force)
+            return
+
         changed = (ranked_dict != self.previous_ranks) or (not self.previous_ranks)
         self.previous_ranks = ranked_dict
         if not (changed or force):
-            return
-        if not ranked_dict:
-            # Nobody placed on the 5s ladder yet — leave the channel alone.
             return
 
         channel = await self._get_board_channel()
@@ -266,6 +275,85 @@ class Ranked5sBoard(commands.Cog):
         to_send = await self._render_board(sorted_results)
         # Ping-free board: silent send, no mentions resolved.
         await leaderboard.wipe_and_post(channel, to_send, self.bot.logging)
+
+    # ------------------------------------------------- match-derived fallback
+
+    async def _fetch_match_standings(self) -> list[dict]:
+        """Standings from our own queue-710 match results (match_stats).
+
+        Wins/losses/winrate per tracked player, best record first. The
+        ingestion stream records every 5s game (cogs/backfill.py fetches
+        queue 710 alongside solo), so this is complete even though no
+        rank/LP exists to show.
+        """
+        rows = await db.fetchall(
+            """SELECT lp.puuid,
+                    lp.league_username,
+                    lp.discord_user_id,
+                    COUNT(*) FILTER (WHERE ms.win = 1) AS wins,
+                    COUNT(*) AS games
+                FROM match_stats ms
+                    JOIN league_players lp ON lp.puuid = ms.puuid
+                WHERE ms.queue_id = %s
+                GROUP BY lp.puuid, lp.league_username, lp.discord_user_id""",
+            (RANKED_5S_QUEUE_ID,),
+        )
+        standings = [
+            {
+                "puuid": puuid,
+                "summonerName": name,
+                "user_id": user_id,
+                "wins": wins,
+                "losses": games - wins,
+                "GamesPlayed": games,
+                "WinRate": (wins / games) * 100 if games else 0.0,
+            }
+            for puuid, name, user_id, wins, games in rows
+        ]
+        standings.sort(key=lambda d: (d["wins"], d["WinRate"], d["GamesPlayed"]), reverse=True)
+        return standings
+
+    async def _post_fallback_board(self, force: bool) -> None:
+        standings = await self._fetch_match_standings()
+        changed = standings != self.previous_fallback
+        self.previous_fallback = standings
+        if not standings or not (changed or force):
+            return
+
+        channel = await self._get_board_channel()
+        if channel is None:
+            return
+
+        header = "**Ranked 5s** — weekend ladder"
+        if not is_ranked5s_open():
+            next_open = next_window_open()
+            if next_open is not None:
+                header += f" (queue closed — opens {next_open.strftime('%A')})"
+            else:
+                header += " (queue closed — test window over)"
+        note = (
+            "-# Riot's API doesn't expose 5s ranks yet — standings from "
+            "match results, sorted by wins."
+        )
+
+        lines = [header, note]
+        for index, entry in enumerate(standings):
+            wins_flags = await db.fetchall(
+                "SELECT win FROM match_stats "
+                "WHERE puuid = %s AND queue_id = %s "
+                "ORDER BY game_start DESC LIMIT 5",
+                (entry["puuid"], RANKED_5S_QUEUE_ID),
+            )
+            last_five = leaderboard.build_last_five_from_wins([w[0] for w in wins_flags])
+            lines.append(
+                f"{index + 1}. {entry['summonerName']} - <@{entry['user_id']}>\n"
+                f"Record: {entry['wins']}W / {entry['losses']}L "
+                f"({entry['WinRate']:.2f}% winrate)\n"
+                f"Last 5: {last_five}\n"
+            )
+
+        self.bot.logging.info("Posting Ranked 5s board (match-derived fallback)")
+        await leaderboard.wipe_and_post(channel, "\n".join(lines), self.bot.logging)
 
     @tasks.loop(seconds=120)
     async def post_ranks_5s(self):
@@ -345,6 +433,12 @@ class Ranked5sBoard(commands.Cog):
             (QUEUE_KEY,),
         )
         ladder_count = row[0] if row else 0
+        row = await db.fetchone(
+            "SELECT COUNT(DISTINCT ms.puuid) FROM match_stats ms "
+            "JOIN league_players lp ON lp.puuid = ms.puuid WHERE ms.queue_id = %s",
+            (RANKED_5S_QUEUE_ID,),
+        )
+        match_count = row[0] if row else 0
         next_open = next_window_open()
         next_open_line = (
             next_open.strftime("%A %Y-%m-%d %H:%M %Z") if next_open else "never (test over)"
@@ -354,7 +448,9 @@ class Ranked5sBoard(commands.Cog):
             f"Tracking: {'yes' if is_ranked5s_tracking() else 'no'}\n"
             f"Next window opens: {next_open_line}\n"
             f"{queue_type_line}\n"
-            f"Players on ladder: {ladder_count}",
+            f"Players with rank entries: {ladder_count} "
+            f"(Riot API exposes no 5s ladder yet — board falls back to match results)\n"
+            f"Players with recorded 5s matches: {match_count}",
             ephemeral=True,
         )
 

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -144,6 +144,17 @@ def build_last_five(rows: list[tuple]) -> str:
     return "".join(reversed(sequence[:5]))
 
 
+def build_last_five_from_wins(wins_newest_first: list) -> str:
+    """Green/red squares straight from per-match win flags, newest right.
+
+    Used by the match-derived Ranked 5s fallback ladder, where exact
+    per-game outcomes are known from match_stats.win — no cumulative-diff
+    reconstruction (and none of its ordering caveats) needed.
+    """
+    squares = [WIN_SQUARE if win else LOSS_SQUARE for win in wins_newest_first[:5]]
+    return "".join(reversed(squares))
+
+
 def count_leading_losses(rows: list[tuple]) -> int:
     """Consecutive losses ending at the most recent game; 0 on a fresh win.
 

--- a/docs/riot-api-reference.md
+++ b/docs/riot-api-reference.md
@@ -65,12 +65,19 @@ Documented in Riot's API reference:
 - `RANKED_FLEX_TT` — legacy Twisted Treeline
 - `RANKED_TFT`, `RANKED_TFT_TURBO`, `RANKED_TFT_DOUBLE_UP` — TFT
 
-**Ranked 5s: the queueType string is NOT yet documented as of 2026-07-04**
-(Riot's OpenAPI enum still only lists the values above).
-`cogs/ranked5s_table_updater.py` auto-discovers it at runtime: any `RANKED_*`
-string not in the known set is treated as the 5s ladder and logged with a
-warning. Once the string shows up in the logs, pin it via the
-`ranked5s_queue_type` env var in `.env` so the heuristic stops guessing.
+**Ranked 5s: the ladder is NOT exposed by the public league API at all —
+verified empirically 2026-07-05.** Evidence: a player with completed 710
+games gets no extra entry from `entries/by-puuid`, and league-exp-v4's own
+400 error enumerates every valid queue value — none is a 5s queue. The
+OpenAPI reference agrees (no new enum, no new endpoint).
+
+Until Riot ships it, `cogs/ranked5s_table_updater.py` renders a
+**match-derived fallback board** (wins/losses/winrate/last-5 from
+`match_stats` queue 710, which `cogs/backfill.py` ingests alongside solo).
+The league-entry path stays in place ahead of it: the cog auto-discovers any
+new `RANKED_*` queueType at runtime, logs it, and can be pinned via the
+`ranked5s_queue_type` env var — the fallback retires itself the first cycle
+real entries appear.
 
 Internally (in `league_history.queue`) Ranked 5s rows are always tagged with
 the repo's own constant **`RANKED_5S`**, decoupled from whatever string Riot


### PR DESCRIPTION
Tested with 8BlitZ (played 2 Ranked 5s games last night): **the public league API does not expose the 5s ladder** — his entries show only solo/flex, and league-exp-v4's own error message enumerates every valid queue enum, none of which is a 5s value. The fresh official-docs scrape agrees. Match-v5 queue **710** works fine (both his games came back).

So until Riot ships the ladder:

- **Ingestion**: the stream/backfill now fetch queue-710 match IDs alongside solo — 5s games land in `match_stats` + `match_raw` (one extra id-page per player per pass).
- **Board fallback**: with no league entries, the 5s board renders match-derived standings — wins/losses/winrate sorted by wins (winrate tiebreak), per-game-accurate last-5 squares, and a small note explaining the API gap. The rank-based path stays ahead of it and retires the fallback automatically the first cycle real entries appear; queueType auto-discovery + `ranked5s_queue_type` pin unchanged.
- `/ranked5s_status` now reports both entry-count and match-count; API reference doc updated with the evidence.

Verified against Postgres 16: standings ordering (incl. the winrate tiebreak), records, last-five rendering. Deploys via cron + auto_reload — no restart needed (no schema change).