### PR TITLE
Keep Ranked 5s games out of the solo-queue analytics

### DIFF
--- a/Bot/utils/match_analysis.py
+++ b/Bot/utils/match_analysis.py
@@ -551,6 +551,10 @@ def load_matches(db_path: str | None = DEFAULT_DB) -> pd.DataFrame:
             FROM match_stats ms
             JOIN league_players lp USING (puuid)
             LEFT JOIN users u ON u.user_id = lp.discord_user_id
+            -- Solo/duo only. match_stats also carries Ranked 5s (queue 710)
+            -- rows since 2026-07-05; every chart in this module is a
+            -- solo-queue analysis, so premade-5 games must not leak in.
+            WHERE ms.queue_id = 420
             ORDER BY ms.game_start ASC
             """,
             con,


### PR DESCRIPTION
Follow-up to #63: match_stats now carries queue-710 rows, and load_matches (the source for every chart) had no queue filter — 5s premade games would silently pollute solo winrate/role/session analytics. Adds WHERE queue_id = 420. Audit of every other match_stats reader: riot_stats (420-filtered), the 5s board (710-filtered), backfill pre-filter (queue-agnostic by design) — all already correct. Functionally verified against Postgres 16 with mixed-queue seed data.