### PR TITLE
Duo-aware Last 5: see who queued together (❎/❌)

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -402,8 +402,8 @@ class Backfill(commands.Cog):
                     "INSERT INTO match_stats "
                     "(match_id, puuid, game_start, queue_id, champion, "
                     " win, kills, deaths, assists, duration_sec, patch_version, "
-                    " position) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                    " position, team_id) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
                     "ON CONFLICT (match_id, puuid) DO NOTHING",
                     (
                         mid,
@@ -418,6 +418,7 @@ class Backfill(commands.Cog):
                         match["info"]["gameDuration"],
                         match["info"].get("gameVersion"),
                         _participant_position(participant),
+                        participant.get("teamId"),
                     ),
                 )
                 inserted += 1

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -8,7 +8,11 @@ from main import MyDiscordBot
 from utils import db, leaderboard
 from utils.loop_restart import restart_loop_later
 from utils.rank_sorting_class import Ranker
-from utils.riot_client import get_account_by_puuid, get_league_entries
+from utils.riot_client import (
+    RANKED_SOLO_QUEUE_ID,
+    get_account_by_puuid,
+    get_league_entries,
+)
 from utils.riot_stats import fetch_recent_kd
 
 # Want to fetch ranks to post from the database
@@ -97,11 +101,29 @@ class FetchFromRiot(commands.Cog):
         return
 
     async def get_last_five_games(self, puuid):
-        # legacy_dual_key: pre-2024 history rows are keyed by the legacy
-        # encrypted summoner ID (league_players.leagueId, ~47 chars), newer
-        # rows by the real puuid (~78 chars).
-        rows = await leaderboard.fetch_history_wl(puuid, SOLO_QUEUE, 6, legacy_dual_key=True)
-        return leaderboard.build_last_five(rows)
+        """Duo-aware Last 5 from actual match results (match_stats).
+
+        A game is a duo game when another tracked player has a row for the
+        same match on the same team (match_stats holds only tracked
+        players). Sourced from match data instead of the old
+        league_history diff reconstruction — exact per-game results and
+        ordering; a game finished within the last ~5 min (stream interval)
+        can show one refresh late. NULL team_id (rows predating the
+        column, not yet backfilled) never counts as duo.
+        """
+        rows = await db.fetchall(
+            "SELECT ms.win, EXISTS ("
+            "    SELECT 1 FROM match_stats o"
+            "    WHERE o.match_id = ms.match_id"
+            "      AND o.team_id = ms.team_id"
+            "      AND o.puuid <> ms.puuid"
+            ") AS duo "
+            "FROM match_stats ms "
+            "WHERE ms.puuid = %s AND ms.queue_id = %s "
+            "ORDER BY ms.game_start DESC LIMIT 5",
+            (puuid, RANKED_SOLO_QUEUE_ID),
+        )
+        return leaderboard.build_last_five_with_duo(rows)
 
     async def get_recent_streak(self, puuid):
         """Return the count of consecutive losses ending at the most recent game.
@@ -227,6 +249,11 @@ class FetchFromRiot(commands.Cog):
                 self.get_last_five_games,
                 apex_omits_games_word=True,
             )
+            if output_list:
+                # Discord small-text legend for the duo-aware Last 5.
+                output_list.append(
+                    "-# Last 5: \U0001f7e9/\U0001f7e5 solo · ❎/❌ duo with a tracked player"
+                )
 
             paste = self.bot.get_channel(919981835428179988)
             await leaderboard.wipe_and_post(paste, "\n".join(output_list), self.bot.logging)

--- a/Bot/db/setup.postgres.sql
+++ b/Bot/db/setup.postgres.sql
@@ -83,9 +83,16 @@ create table if not exists match_stats (
     -- actual role played that game. Empty "" on remakes / very old matches;
     -- NULL on rows inserted before this column existed.
     position TEXT,
+    -- Riot Match-V5 teamId (100 blue / 200 red). Two tracked players with
+    -- the same match_id AND team_id played together (duo detection for the
+    -- board's Last 5). NULL on rows from before this column existed —
+    -- backfillable from match_raw payloads with a single UPDATE, no API.
+    team_id SMALLINT,
     primary key (match_id, puuid)
 );
 create index if not exists idx_match_stats_puuid_time on match_stats (puuid, game_start desc);
+-- Existing installs predate the column; CREATE IF NOT EXISTS won't add it.
+alter table match_stats add column if not exists team_id SMALLINT;
 
 -- Complete Match-V5 JSON payload, archived verbatim at ingest. One row per
 -- MATCH (not per participant — tracked players often share a game; the

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -21,6 +21,8 @@ APEX_TIERS = ("Master", "Grandmaster", "Challenger")
 
 WIN_SQUARE = "\U0001f7e9"  # green square
 LOSS_SQUARE = "\U0001f7e5"  # red square
+DUO_WIN_SQUARE = "❎"  # green box with an X — duo win
+DUO_LOSS_SQUARE = "❌"  # red X — duo loss
 
 
 # ------------------------------------------------------------------ history
@@ -152,6 +154,23 @@ def build_last_five_from_wins(wins_newest_first: list) -> str:
     reconstruction (and none of its ordering caveats) needed.
     """
     squares = [WIN_SQUARE if win else LOSS_SQUARE for win in wins_newest_first[:5]]
+    return "".join(reversed(squares))
+
+
+def build_last_five_with_duo(games_newest_first: list[tuple]) -> str:
+    """Squares for up to 5 games with duo marking, newest on the right.
+
+    ``games_newest_first`` are (win, duo) pairs straight from match_stats:
+    win 1/0, duo True when another tracked player shared the player's team
+    in that game. Duo games swap the plain square for the X'd variant:
+    solo win 🟩 / duo win ❎ / solo loss 🟥 / duo loss ❌.
+    """
+    squares = []
+    for win, duo in games_newest_first[:5]:
+        if win:
+            squares.append(DUO_WIN_SQUARE if duo else WIN_SQUARE)
+        else:
+            squares.append(DUO_LOSS_SQUARE if duo else LOSS_SQUARE)
     return "".join(reversed(squares))
 
 


### PR DESCRIPTION
William's ask: on the ranking, show which of the last 5 games were played together vs alone.

- New `match_stats.team_id` (Riot `teamId`) — ingested on every new match, and backfilled for existing rows **from the local `match_raw` payloads with a single UPDATE, zero API calls** (the raw-archive design doing its job). Prod column already added + backfilled ahead of this merge; rows whose raw payload hasn't been healed yet stay NULL and safely render as solo until the heal finishes.
- Duo = another tracked player with a row for the **same match on the same team**. Facing a tracked friend on the enemy team is not a duo.
- The solo board's Last 5 now comes from actual match results (not LP-history diff reconstruction): solo win 🟩 · duo win ❎ · solo loss 🟥 · duo loss ❌, with a small `-#` legend under the board.
- Known limits: a duo with an *untracked* player can't be detected (Riot exposes no premade info), and a game finished within the last ~5 min can show one refresh late.

Verified against Postgres 16 with a seeded scenario covering duo win, duo loss, solo loss, tracked-enemy (correctly plain), NULL team_id, ordering, and both partners' views.