### PR TITLE
Fix broken solo board (2000-char cap) + hybrid 5s board with placements

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -256,7 +256,9 @@ class FetchFromRiot(commands.Cog):
                 )
 
             paste = self.bot.get_channel(919981835428179988)
-            await leaderboard.wipe_and_post(paste, "\n".join(output_list), self.bot.logging)
+            # Blocks, not a joined string — the board can exceed Discord's
+            # 2000-char message cap and gets split on entry boundaries.
+            await leaderboard.wipe_and_post(paste, output_list, self.bot.logging)
 
         # Watchdog input: heartbeat cog reads this and reloads us if it
         # goes stale (typically because a Gateway disconnect left the

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -215,7 +215,8 @@ class Ranked5sBoard(commands.Cog):
 
     # ----------------------------------------------------------------- render
 
-    async def _render_board(self, sorted_results: list[dict]) -> str:
+    async def _render_board(self, sorted_results: list[dict]) -> list[str]:
+        """Board blocks (header + one block per entry) for wipe_and_post."""
         header = "**Ranked 5s** — weekend ladder"
         if not is_ranked5s_open():
             next_open = next_window_open()
@@ -232,7 +233,7 @@ class Ranked5sBoard(commands.Cog):
             self.last_updated_by,
             self._get_last_five_games,
         )
-        return "\n".join([header] + entries)
+        return [header] + entries
 
     # ------------------------------------------------------------------- loop
 
@@ -253,17 +254,25 @@ class Ranked5sBoard(commands.Cog):
             self.last_updated_by = updated_users
 
         if not ranked_dict:
-            # Riot's league API doesn't expose the Ranked 5s ladder (no
-            # queue enum, no endpoint — verified 2026-07-05), so until it
-            # does, nobody has an entry here and the board falls back to
-            # match-derived standings. The moment Riot ships the ladder,
-            # ranked_dict fills and this path retires itself.
+            # League entries only exist for players who've completed
+            # placements (RANKED_PREMADE_5x5, shipped by Riot 2026-07-05).
+            # With nobody placed yet, the board is match-derived standings.
             await self._post_fallback_board(force)
             return
 
         changed = (ranked_dict != self.previous_ranks) or (not self.previous_ranks)
         self.previous_ranks = ranked_dict
-        if not (changed or force):
+
+        # Hybrid: tracked players with 5s games but no entry yet (still in
+        # placements) appear in a compact section under the ranked board —
+        # otherwise they vanish the moment the first friend gets a rank.
+        standings = await self._fetch_match_standings()
+        ranked_puuids = {entry["puuid"] for entry in ranked_dict.values()}
+        unplaced = [s for s in standings if s["puuid"] not in ranked_puuids]
+        unplaced_changed = unplaced != self.previous_fallback
+        self.previous_fallback = unplaced
+
+        if not (changed or unplaced_changed or force):
             return
 
         channel = await self._get_board_channel()
@@ -272,9 +281,16 @@ class Ranked5sBoard(commands.Cog):
 
         self.bot.logging.info("Posting Ranked 5s board")
         sorted_results = sorted(ranked_dict.values(), key=lambda d: d["sorted_rank"], reverse=True)
-        to_send = await self._render_board(sorted_results)
-        # Ping-free board: silent send, no mentions resolved.
-        await leaderboard.wipe_and_post(channel, to_send, self.bot.logging)
+        blocks = await self._render_board(sorted_results)
+        if unplaced:
+            blocks.append("-# In placements (no rank yet) — match record:")
+            for entry in unplaced:
+                blocks.append(
+                    f"{entry['summonerName']} - <@{entry['user_id']}>: "
+                    f"{entry['wins']}W / {entry['losses']}L"
+                )
+        # Ping-free board: silent sends, no mentions resolved.
+        await leaderboard.wipe_and_post(channel, blocks, self.bot.logging)
 
     # ------------------------------------------------- match-derived fallback
 
@@ -353,7 +369,7 @@ class Ranked5sBoard(commands.Cog):
             )
 
         self.bot.logging.info("Posting Ranked 5s board (match-derived fallback)")
-        await leaderboard.wipe_and_post(channel, "\n".join(lines), self.bot.logging)
+        await leaderboard.wipe_and_post(channel, lines, self.bot.logging)
 
     @tasks.loop(seconds=120)
     async def post_ranks_5s(self):

--- a/Bot/utils/config.py
+++ b/Bot/utils/config.py
@@ -57,5 +57,11 @@ def riot_api_key() -> str | None:
 
 
 def ranked5s_queue_type() -> str | None:
-    """Pinned league-v4 queueType for Ranked 5s (unset = auto-discover)."""
-    return os.environ.get("ranked5s_queue_type")
+    """league-v4 queueType for Ranked 5s entries.
+
+    Confirmed from live entries on 2026-07-05: entries appear once a
+    player finishes placements, tagged RANKED_PREMADE_5x5. The env var
+    overrides in case Riot renames it; setting it to an empty value
+    re-enables the cog's auto-discovery heuristic.
+    """
+    return os.environ.get("ranked5s_queue_type", "RANKED_PREMADE_5x5")

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -274,21 +274,53 @@ async def render_board_entries(
 # ------------------------------------------------------------------ posting
 
 
-async def wipe_and_post(channel, content: str, log) -> None:
+MESSAGE_CHAR_LIMIT = 2000  # Discord hard limit per message
+
+
+def chunk_blocks(blocks: list[str], limit: int = MESSAGE_CHAR_LIMIT) -> list[str]:
+    """Pack blocks into as few messages as possible without splitting one.
+
+    Blocks are joined with newlines. A single block longer than ``limit``
+    (shouldn't happen for board entries) is hard-split as a last resort
+    rather than dropped.
+    """
+    messages: list[str] = []
+    current = ""
+    for block in blocks:
+        candidate = f"{current}\n{block}" if current else block
+        if len(candidate) <= limit:
+            current = candidate
+            continue
+        if current:
+            messages.append(current)
+        while len(block) > limit:
+            messages.append(block[:limit])
+            block = block[limit:]
+        current = block
+    if current:
+        messages.append(current)
+    return messages
+
+
+async def wipe_and_post(channel, content, log) -> None:
     """Delete the channel's message history, then silently post ``content``.
 
-    Boards are ping-free: silent send + no mentions resolved. Empty
-    ``content`` still wipes but posts nothing (solo board with an empty
-    entry list).
+    ``content`` is a list of blocks (or a single string): a board that
+    outgrows Discord's 2000-char message limit is split across several
+    messages on block boundaries — a full board once silently failed with
+    a 400 after the wipe, leaving the channel empty. Boards are ping-free:
+    silent sends, no mentions resolved. Empty content still wipes but
+    posts nothing.
     """
+    blocks = [content] if isinstance(content, str) else [b for b in content if b]
     try:
         async for message in channel.history():
             await message.delete()
     except discord.errors.Forbidden:
         log.warning("Missing permissions to delete messages, skipping cleanup")
-    if content:
+    for message_text in chunk_blocks(blocks):
         await channel.send(
-            content,
+            message_text,
             silent=True,
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/docs/riot-api-reference.md
+++ b/docs/riot-api-reference.md
@@ -65,19 +65,19 @@ Documented in Riot's API reference:
 - `RANKED_FLEX_TT` — legacy Twisted Treeline
 - `RANKED_TFT`, `RANKED_TFT_TURBO`, `RANKED_TFT_DOUBLE_UP` — TFT
 
-**Ranked 5s: the ladder is NOT exposed by the public league API at all —
-verified empirically 2026-07-05.** Evidence: a player with completed 710
-games gets no extra entry from `entries/by-puuid`, and league-exp-v4's own
-400 error enumerates every valid queue value — none is a 5s queue. The
-OpenAPI reference agrees (no new enum, no new endpoint).
+**Ranked 5s: `RANKED_PREMADE_5x5` — confirmed from live entries
+2026-07-05.** An entry appears in `entries/by-puuid` only once the player
+completes placements; before that the player has 710 matches but no entry.
+(Beware: league-exp-v4's queue enum still rejects the string, and the
+OpenAPI docs don't list it — live entries are the source of truth. The
+cog's auto-discovery heuristic caught it in prod logs.)
 
-Until Riot ships it, `cogs/ranked5s_table_updater.py` renders a
-**match-derived fallback board** (wins/losses/winrate/last-5 from
-`match_stats` queue 710, which `cogs/backfill.py` ingests alongside solo).
-The league-entry path stays in place ahead of it: the cog auto-discovers any
-new `RANKED_*` queueType at runtime, logs it, and can be pinned via the
-`ranked5s_queue_type` env var — the fallback retires itself the first cycle
-real entries appear.
+`cogs/ranked5s_table_updater.py` renders a **hybrid board**: real ranks for
+placed players, plus an "in placements" section from match results
+(`match_stats` queue 710, ingested alongside solo by `cogs/backfill.py`).
+With no entries at all it falls back to pure match-derived standings. The
+pinned string lives in `utils/config.py` (env `ranked5s_queue_type`
+overrides; empty value re-enables auto-discovery).
 
 Internally (in `league_history.queue`) Ranked 5s rows are always tagged with
 the repo's own constant **`RANKED_5S`**, decoupled from whatever string Riot


### PR DESCRIPTION
Fixes the broken leaderboard: the duo legend pushed the single-message board past Discord's 2000-char limit — the wipe ran, the send 400'd, and the channel was left empty. `wipe_and_post` now packs entry blocks into as many ≤2000-char messages as needed (splitting only between entries), for both boards.

Also: **Riot shipped the 5s ladder today** — the discovery heuristic caught `RANKED_PREMADE_5x5` in prod logs (entries appear per player once placements finish; note league-exp's enum still rejects the string, live entries are the truth). It's now the pinned in-code default. And the rank-based 5s board no longer drops unplaced players: they get an "in placements — match record" section under the ranked entries.

Verified end-to-end through a fake channel this time: 25-entry board → 2 messages, all ≤2000 chars, content byte-identical, wipe still runs; oversize hard-split; pinned entry picker; unplaced-section selection against Postgres 16.