### PR TITLE
Board key at the top, drop 'Last 5:' labels

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -250,9 +250,12 @@ class FetchFromRiot(commands.Cog):
                 apex_omits_games_word=True,
             )
             if output_list:
-                # Discord small-text legend for the duo-aware Last 5.
-                output_list.append(
-                    "-# Last 5: \U0001f7e9/\U0001f7e5 solo · ❎/❌ duo with a tracked player"
+                # Key at the top of the board (William's call) — explains
+                # the per-entry squares, which carry no label of their own.
+                output_list.insert(
+                    0,
+                    "-# Key: \U0001f7e9 solo win · ❎ duo win · "
+                    "\U0001f7e5 solo loss · ❌ duo loss",
                 )
 
             paste = self.bot.get_channel(919981835428179988)

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -365,7 +365,7 @@ class Ranked5sBoard(commands.Cog):
                 f"{index + 1}. {entry['summonerName']} - <@{entry['user_id']}>\n"
                 f"Record: {entry['wins']}W / {entry['losses']}L "
                 f"({entry['WinRate']:.2f}% winrate)\n"
-                f"Last 5: {last_five}\n"
+                f"{last_five}\n"
             )
 
         self.bot.logging.info("Posting Ranked 5s board (match-derived fallback)")

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -218,7 +218,9 @@ def render_board_entry(
     else:
         position_arrow = "\U00002b07\U0000fe0f "
     updated_flag = " \U0001f6a9" if updated else ""  # triangular flag
-    last_five_line = f"Last 5: {last_five}\n" if last_five else ""
+    # Bare squares, no "Last 5:" label — the boards carry a key up top and
+    # the squares are self-explanatory (William's call).
+    last_five_line = f"{last_five}\n" if last_five else ""
 
     tier = posting["tier"].title()
     is_apex = tier in APEX_TIERS


### PR DESCRIPTION
Per William: the solo board now leads with the key line (-# Key: 🟩 solo win · ❎ duo win · 🟥 solo loss · ❌ duo loss) and the per-entry 'Last 5:' labels are gone on both boards — bare squares, self-explanatory. Verified render output contains squares without the label.