### PR TITLE
feat(boards): last-played line + data-derived flag + render-gated reposts

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -36,9 +36,15 @@ class FetchFromRiot(commands.Cog):
         # self.fetch_ranks_from_riot.start()
         self.previous_ranks = {}
         self.min_games_played = 0
-        self.last_updated_by: list[str] = []
         self.streak_pinged: set[str] = set()
+        # Arrow state: previous_positions is the pre-reshuffle baseline the
+        # arrows diff against, last_positions is last cycle's standings —
+        # see leaderboard.render_board_entries.
         self.previous_positions: dict[str, int] = {}
+        self.last_positions: dict[str, int] = {}
+        # Blocks of the last posted board — the post gate. In-memory, so
+        # the first cycle after a hot reload reposts once redundantly.
+        self.previous_output: list[str] | None = None
         self.post_ranks_last_fired: dt.datetime | None = None
 
         self.ranked_dict: dict | None = None
@@ -101,7 +107,7 @@ class FetchFromRiot(commands.Cog):
         return
 
     async def get_last_five_games(self, puuid):
-        """Duo-aware Last 5 from actual match results (match_stats).
+        """Duo-aware Last 5 + last-played timestamp from match results.
 
         A game is a duo game when another tracked player has a row for the
         same match on the same team (match_stats holds only tracked
@@ -110,6 +116,10 @@ class FetchFromRiot(commands.Cog):
         ordering; a game finished within the last ~5 min (stream interval)
         can show one refresh late. NULL team_id (rows predating the
         column, not yet backfilled) never counts as duo.
+
+        Returns ``(squares, last_played)`` — last_played is the newest
+        game_start (same rows, no extra roundtrip), None when the player
+        has no recorded games.
         """
         rows = await db.fetchall(
             "SELECT ms.win, EXISTS ("
@@ -117,13 +127,14 @@ class FetchFromRiot(commands.Cog):
             "    WHERE o.match_id = ms.match_id"
             "      AND o.team_id = ms.team_id"
             "      AND o.puuid <> ms.puuid"
-            ") AS duo "
+            ") AS duo, ms.game_start "
             "FROM match_stats ms "
             "WHERE ms.puuid = %s AND ms.queue_id = %s "
             "ORDER BY ms.game_start DESC LIMIT 5",
             (puuid, RANKED_SOLO_QUEUE_ID),
         )
-        return leaderboard.build_last_five_with_duo(rows)
+        squares = leaderboard.build_last_five_with_duo([(win, duo) for win, duo, _ in rows])
+        return squares, rows[0][2] if rows else None
 
     async def get_recent_streak(self, puuid):
         """Return the count of consecutive losses ending at the most recent game.
@@ -190,10 +201,10 @@ class FetchFromRiot(commands.Cog):
     async def post_ranks(self):
         await self.bot.wait_until_ready()
         await self.fetch_ranks_from_riot()
-        # if len(self.previous_ranks) == 0:
-        #     self.previous_ranks = self.ranked_dict
-        #     return
 
+        # LP-diff bookkeeping stays gated on the fetched ranks moving:
+        # check_name is an account-v1 call per player, and the history
+        # snapshots / streak ping only have anything to do on a change.
         if (self.ranked_dict != self.previous_ranks) or (not self.previous_ranks):
             updated_users: list[str] = []
             for user in self.ranked_dict.keys():
@@ -207,9 +218,6 @@ class FetchFromRiot(commands.Cog):
                         print(f"{user} updated", flush=True)
                         await self.update_table(user, self.ranked_dict[user])
                         updated_users.append(user)
-
-            if updated_users:
-                self.last_updated_by = updated_users
 
             # Streak ping: only check players whose LP changed this cycle so
             # we don't spam Riot's DB on every refresh. Posts once when a
@@ -225,39 +233,48 @@ class FetchFromRiot(commands.Cog):
                 elif streak < STREAK_THRESHOLD and user in self.streak_pinged:
                     self.streak_pinged.discard(user)
 
-            self.bot.logging.info("Posting ranks")
             self.previous_ranks = self.ranked_dict
-            to_post = filter(
-                lambda x: isinstance(x, dict),
-                [data for data in self.ranked_dict.values()],
+
+        # Render every cycle, not just on rank changes: match_stats rows
+        # land via the separate ~5-min stream loop, so squares/flag/
+        # last-played can change with no LP movement. Post iff the
+        # rendered blocks differ from the last posted board.
+        to_post = filter(
+            lambda x: isinstance(x, dict),
+            [data for data in self.ranked_dict.values()],
+        )
+        # Sort by rank
+        sorted_results = sorted(to_post, key=lambda d: d["sorted_rank"], reverse=True)
+
+        # Sort by winrate
+        # sorted_results = sorted(to_post,
+        #                         key=lambda d: d["WinRate"],
+        #                         reverse=True)
+
+        # apex_omits_games_word: this board's apex entries have always
+        # read "Played: N with a ..." — see utils/leaderboard.py.
+        (
+            output_list,
+            self.previous_positions,
+            self.last_positions,
+        ) = await leaderboard.render_board_entries(
+            sorted_results,
+            self.previous_positions,
+            self.last_positions,
+            self.get_last_five_games,
+            apex_omits_games_word=True,
+        )
+        if output_list:
+            # Key at the top of the board (William's call) — explains
+            # the per-entry squares, which carry no label of their own.
+            output_list.insert(
+                0,
+                "-# Key: \U0001f7e9 solo win · ❎ duo win · \U0001f7e5 solo loss · ❌ duo loss",
             )
-            # Sort by rank
-            sorted_results = sorted(to_post, key=lambda d: d["sorted_rank"], reverse=True)
 
-            # Sort by winrate
-            # sorted_results = sorted(to_post,
-            #                         key=lambda d: d["WinRate"],
-            #                         reverse=True)
-
-            # apex_omits_games_word: this board's apex entries have always
-            # read "Played: N with a ..." — see utils/leaderboard.py.
-            # previous_positions feeds next cycle's arrow comparisons.
-            output_list, self.previous_positions = await leaderboard.render_board_entries(
-                sorted_results,
-                self.previous_positions,
-                self.last_updated_by,
-                self.get_last_five_games,
-                apex_omits_games_word=True,
-            )
-            if output_list:
-                # Key at the top of the board (William's call) — explains
-                # the per-entry squares, which carry no label of their own.
-                output_list.insert(
-                    0,
-                    "-# Key: \U0001f7e9 solo win · ❎ duo win · "
-                    "\U0001f7e5 solo loss · ❌ duo loss",
-                )
-
+        if output_list != self.previous_output:
+            self.previous_output = output_list
+            self.bot.logging.info("Posting ranks")
             paste = self.bot.get_channel(919981835428179988)
             # Blocks, not a joined string — the board can exceed Discord's
             # 2000-char message cap and gets split on entry boundaries.

--- a/Bot/cogs/ranked5s_table_updater.py
+++ b/Bot/cogs/ranked5s_table_updater.py
@@ -60,9 +60,13 @@ class Ranked5sBoard(commands.Cog):
         self.bot = bot
         self.bot.logging.info(f"{__name__} loaded")
         self.post_ranks_5s.start()
-        self.previous_ranks: dict = {}
-        self.last_updated_by: list[str] = []
+        # Arrow state + post gate, same contract as FetchFromRiot — see
+        # leaderboard.render_board_entries. previous_output covers both
+        # the ranked board and the match-derived fallback (they share the
+        # channel, so only one is ever the "last posted board").
         self.previous_positions: dict[str, int] = {}
+        self.last_positions: dict[str, int] = {}
+        self.previous_output: list[str] | None = None
         # Watchdog input, same contract as FetchFromRiot.post_ranks_last_fired
         # (cogs/heartbeat.py reloads us if this goes stale).
         self.post_ranks_5s_last_fired: dt.datetime | None = None
@@ -70,9 +74,6 @@ class Ranked5sBoard(commands.Cog):
         # cog instance, not once per loop tick.
         self._seen_queue_types: set[str] = set()
         self._warned_no_channel = False
-        # Last match-derived fallback standings (used while Riot's league
-        # API exposes no 5s ladder) — change detection for reposts.
-        self.previous_fallback: list[dict] = []
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
@@ -183,10 +184,19 @@ class Ranked5sBoard(commands.Cog):
                 f"{entry['wins']}W/{entry['losses']}L"
             )
 
-    async def _get_last_five_games(self, puuid: str) -> str:
-        """Green/red squares for the player's last 5 games on the 5s ladder."""
+    async def _get_last_five_games(self, puuid: str) -> tuple[str, dt.datetime | None]:
+        """Squares + last-played for the player's games on the 5s ladder.
+
+        Squares still come from league_history diffs; the last-played
+        timestamp needs a real clock, which only match_stats has (queue-710
+        rows from the ingestion stream), so it's a separate lookup.
+        """
         rows = await leaderboard.fetch_history_wl(puuid, QUEUE_KEY, 6)
-        return leaderboard.build_last_five(rows)
+        latest = await db.fetchone(
+            "SELECT MAX(game_start) FROM match_stats WHERE puuid = %s AND queue_id = %s",
+            (puuid, RANKED_5S_QUEUE_ID),
+        )
+        return leaderboard.build_last_five(rows), latest[0] if latest else None
 
     # ---------------------------------------------------------------- channel
 
@@ -225,12 +235,16 @@ class Ranked5sBoard(commands.Cog):
             else:
                 header += " (queue closed — test window over)"
 
-        # previous_positions feeds next cycle's arrow comparisons. Unlike
+        # previous_positions/last_positions feed the arrow baseline. Unlike
         # the solo board, apex entries here keep the " games " wording.
-        entries, self.previous_positions = await leaderboard.render_board_entries(
+        (
+            entries,
+            self.previous_positions,
+            self.last_positions,
+        ) = await leaderboard.render_board_entries(
             sorted_results,
             self.previous_positions,
-            self.last_updated_by,
+            self.last_positions,
             self._get_last_five_games,
         )
         return [header] + entries
@@ -239,19 +253,13 @@ class Ranked5sBoard(commands.Cog):
 
     async def _run_cycle(self, force: bool = False) -> None:
         """One full fetch -> history -> post pass. ``force`` reposts even
-        when nothing changed (used by /refresh_ranked5s)."""
+        when the rendered board is unchanged (used by /refresh_ranked5s)."""
         players = await self._fetch_tracked_players()
         ranked_dict = await self._fetch_5s_ranks(players)
 
-        # Record history + collect the flag list even if no channel is set.
-        updated_users: list[str] = []
-        for user, entry in ranked_dict.items():
-            previous = self.previous_ranks.get(user)
-            if previous is not None and entry["leaguePoints"] != previous["leaguePoints"]:
-                updated_users.append(user)
+        # Record history even if no channel is set.
+        for entry in ranked_dict.values():
             await self._record_history(entry)
-        if updated_users:
-            self.last_updated_by = updated_users
 
         if not ranked_dict:
             # League entries only exist for players who've completed
@@ -260,26 +268,17 @@ class Ranked5sBoard(commands.Cog):
             await self._post_fallback_board(force)
             return
 
-        changed = (ranked_dict != self.previous_ranks) or (not self.previous_ranks)
-        self.previous_ranks = ranked_dict
-
         # Hybrid: tracked players with 5s games but no entry yet (still in
         # placements) appear in a compact section under the ranked board —
         # otherwise they vanish the moment the first friend gets a rank.
         standings = await self._fetch_match_standings()
         ranked_puuids = {entry["puuid"] for entry in ranked_dict.values()}
         unplaced = [s for s in standings if s["puuid"] not in ranked_puuids]
-        unplaced_changed = unplaced != self.previous_fallback
-        self.previous_fallback = unplaced
 
-        if not (changed or unplaced_changed or force):
-            return
-
-        channel = await self._get_board_channel()
-        if channel is None:
-            return
-
-        self.bot.logging.info("Posting Ranked 5s board")
+        # Render every cycle, not just on rank changes: match_stats rows
+        # land via the separate ~5-min stream loop, so squares/flag/
+        # last-played can change with no LP movement. Post iff the
+        # rendered blocks differ from the last posted board.
         sorted_results = sorted(ranked_dict.values(), key=lambda d: d["sorted_rank"], reverse=True)
         blocks = await self._render_board(sorted_results)
         if unplaced:
@@ -289,6 +288,16 @@ class Ranked5sBoard(commands.Cog):
                     f"{entry['summonerName']} - <@{entry['user_id']}>: "
                     f"{entry['wins']}W / {entry['losses']}L"
                 )
+
+        if blocks == self.previous_output and not force:
+            return
+
+        channel = await self._get_board_channel()
+        if channel is None:
+            return
+
+        self.bot.logging.info("Posting Ranked 5s board")
+        self.previous_output = blocks
         # Ping-free board: silent sends, no mentions resolved.
         await leaderboard.wipe_and_post(channel, blocks, self.bot.logging)
 
@@ -331,13 +340,7 @@ class Ranked5sBoard(commands.Cog):
 
     async def _post_fallback_board(self, force: bool) -> None:
         standings = await self._fetch_match_standings()
-        changed = standings != self.previous_fallback
-        self.previous_fallback = standings
-        if not standings or not (changed or force):
-            return
-
-        channel = await self._get_board_channel()
-        if channel is None:
+        if not standings:
             return
 
         header = "**Ranked 5s** — weekend ladder"
@@ -352,23 +355,49 @@ class Ranked5sBoard(commands.Cog):
             "match results, sorted by wins."
         )
 
-        lines = [header, note]
-        for index, entry in enumerate(standings):
-            wins_flags = await db.fetchall(
-                "SELECT win FROM match_stats "
+        # Fetch every entry's recent games first: the 🚩 marks whoever
+        # played the board-wide most recent game, which isn't known until
+        # all of them are in hand. Fallback standings come FROM match_stats,
+        # so last_played always exists here.
+        recents: list[tuple[str, dt.datetime | None]] = []
+        for entry in standings:
+            rows = await db.fetchall(
+                "SELECT win, game_start FROM match_stats "
                 "WHERE puuid = %s AND queue_id = %s "
                 "ORDER BY game_start DESC LIMIT 5",
                 (entry["puuid"], RANKED_5S_QUEUE_ID),
             )
-            last_five = leaderboard.build_last_five_from_wins([w[0] for w in wins_flags])
+            last_five = leaderboard.build_last_five_from_wins([win for win, _ in rows])
+            recents.append((last_five, rows[0][1] if rows else None))
+        freshest = leaderboard.freshest_played(played for _, played in recents)
+
+        lines = [header, note]
+        for index, (entry, (last_five, last_played)) in enumerate(
+            zip(standings, recents, strict=True)
+        ):
+            flag = (
+                f" {leaderboard.FLAG}"
+                if last_played is not None and last_played == freshest
+                else ""
+            )
             lines.append(
-                f"{index + 1}. {entry['summonerName']} - <@{entry['user_id']}>\n"
+                f"{index + 1}. {entry['summonerName']} - <@{entry['user_id']}>{flag}\n"
                 f"Record: {entry['wins']}W / {entry['losses']}L "
                 f"({entry['WinRate']:.2f}% winrate)\n"
+                f"{leaderboard.last_played_line(last_played)}"
                 f"{last_five}\n"
             )
 
+        # Same rendered-output post gate as the ranked board.
+        if lines == self.previous_output and not force:
+            return
+
+        channel = await self._get_board_channel()
+        if channel is None:
+            return
+
         self.bot.logging.info("Posting Ranked 5s board (match-derived fallback)")
+        self.previous_output = lines
         await leaderboard.wipe_and_post(channel, lines, self.bot.logging)
 
     @tasks.loop(seconds=120)

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -207,14 +207,15 @@ def last_played_line(last_played: dt.datetime | None) -> str:
     """``Last played:`` line for one entry, '' when the player has no games.
 
     ``last_played`` is the newest match_stats.game_start (tz-aware
-    datetime, or None). Both <t:..> forms are rendered client-side by
-    Discord, so the message content stays byte-stable as time passes —
-    the line can't retrigger the rendered-output post gate on its own.
+    datetime, or None). Relative-only (<t:..:R>, "3 hours ago" — William's
+    call) and rendered client-side by Discord, so the message content
+    stays byte-stable as time passes — the line can't retrigger the
+    rendered-output post gate on its own.
     """
     epoch = epoch_seconds(last_played)
     if epoch is None:
         return ""
-    return f"Last played: <t:{epoch}:d> (<t:{epoch}:R>)\n"
+    return f"Last played: <t:{epoch}:R>\n"
 
 
 def freshest_played(played_values) -> dt.datetime | None:

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -14,6 +14,8 @@ puuid, so solo reads must union both keys (``legacy_dual_key=True``).
 Ranked 5s rows are always puuid-keyed.
 """
 
+import datetime as dt
+
 import discord
 from utils import db
 
@@ -23,6 +25,7 @@ WIN_SQUARE = "\U0001f7e9"  # green square
 LOSS_SQUARE = "\U0001f7e5"  # red square
 DUO_WIN_SQUARE = "❎"  # green box with an X — duo win
 DUO_LOSS_SQUARE = "❌"  # red X — duo loss
+FLAG = "\U0001f6a9"  # triangular flag — marks the board's freshest game
 
 
 # ------------------------------------------------------------------ history
@@ -195,16 +198,46 @@ def count_leading_losses(rows: list[tuple]) -> int:
 # ------------------------------------------------------------------- render
 
 
+def epoch_seconds(moment: dt.datetime | None) -> int | None:
+    """tz-aware datetime -> unix seconds (int) for Discord <t:...> markup."""
+    return None if moment is None else int(moment.timestamp())
+
+
+def last_played_line(last_played: dt.datetime | None) -> str:
+    """``Last played:`` line for one entry, '' when the player has no games.
+
+    ``last_played`` is the newest match_stats.game_start (tz-aware
+    datetime, or None). Both <t:..> forms are rendered client-side by
+    Discord, so the message content stays byte-stable as time passes —
+    the line can't retrigger the rendered-output post gate on its own.
+    """
+    epoch = epoch_seconds(last_played)
+    if epoch is None:
+        return ""
+    return f"Last played: <t:{epoch}:d> (<t:{epoch}:R>)\n"
+
+
+def freshest_played(played_values) -> dt.datetime | None:
+    """Board-wide most recent last_played; None when nobody has games.
+
+    Entries tying this value get the 🚩 — an exact game_start tie means
+    the same match, so duo/premade partners are flagged together.
+    """
+    return max((played for played in played_values if played is not None), default=None)
+
+
 def render_board_entry(
     posting: dict,
     position: int,
     previous_position: int | None,
     updated: bool,
     last_five: str,
+    last_played: dt.datetime | None = None,
     *,
     apex_omits_games_word: bool = False,
 ) -> str:
-    """One board entry: name/arrow/flag line, rank line, played line, last-5.
+    """One board entry: name/arrow/flag line, rank line, played line,
+    last-played line, last-5.
 
     ``apex_omits_games_word`` reproduces the solo board's long-standing
     quirk where apex entries read "Played: N with a ..." (no "games") while
@@ -217,7 +250,7 @@ def render_board_entry(
         position_arrow = "\U00002b06\U0000fe0f "
     else:
         position_arrow = "\U00002b07\U0000fe0f "
-    updated_flag = " \U0001f6a9" if updated else ""  # triangular flag
+    updated_flag = f" {FLAG}" if updated else ""
     # Bare squares, no "Last 5:" label — the boards carry a key up top and
     # the squares are self-explanatory (William's call).
     last_five_line = f"{last_five}\n" if last_five else ""
@@ -235,6 +268,7 @@ def render_board_entry(
         f"{updated_flag}\n"
         f"{rank_line}\n"
         f"Played: {posting['GamesPlayed']}{games_word} with a {posting['WinRate']:.2f}% winrate\n"
+        f"{last_played_line(last_played)}"
         f"{last_five_line}"
     )
 
@@ -242,35 +276,55 @@ def render_board_entry(
 async def render_board_entries(
     sorted_results: list[dict],
     previous_positions: dict[str, int],
-    last_updated_by: list[str],
+    last_positions: dict[str, int],
     fetch_last_five,
     *,
     apex_omits_games_word: bool = False,
-) -> tuple[list[str], dict[str, int]]:
+) -> tuple[list[str], dict[str, int], dict[str, int]]:
     """Render every entry of an already-sorted board.
 
-    Returns ``(entry_strings, current_positions)`` — the caller stores
-    ``current_positions`` for the next cycle's arrow comparisons.
-    ``fetch_last_five`` is an async ``puuid -> squares-string`` callable so
-    each cog keeps its own history scoping (queue tag / legacy dual key).
+    Returns ``(entry_strings, arrow_baseline, current_positions)`` — the
+    caller stores both dicts for the next cycle. The boards re-render every
+    cycle (the post gate compares rendered output, see the cogs), so arrows
+    can't diff against the previous render — they'd erase themselves, and
+    force a repost, one cycle after appearing. Instead the arrow baseline
+    only advances when the standings actually reshuffle, so arrows persist
+    until the next reshuffle.
+
+    ``fetch_last_five`` is an async ``puuid -> (squares, last_played)``
+    callable so each cog keeps its own scoping (queue tag / legacy dual
+    key); ``last_played`` is the newest game_start datetime, None when the
+    player has no recorded games.
+
+    The 🚩 is data-derived (survives hot reloads, catches 0-LP
+    demotion-shield games): it marks the entry/entries whose last_played
+    is the board-wide most recent — see :func:`freshest_played`.
     """
+    current_positions = {
+        posting["summonerName"]: index + 1 for index, posting in enumerate(sorted_results)
+    }
+    if current_positions != last_positions:
+        previous_positions = last_positions
+
+    fetched = [await fetch_last_five(posting["puuid"]) for posting in sorted_results]
+    freshest = freshest_played(played for _, played in fetched)
+
     output_list: list[str] = []
-    current_positions: dict[str, int] = {}
-    for index, posting in enumerate(sorted_results):
-        position = index + 1
-        name = posting["summonerName"]
-        current_positions[name] = position
+    for index, (posting, (last_five, last_played)) in enumerate(
+        zip(sorted_results, fetched, strict=True)
+    ):
         output_list.append(
             render_board_entry(
                 posting,
-                position,
-                previous_positions.get(name),
-                name in last_updated_by,
-                await fetch_last_five(posting["puuid"]),
+                index + 1,
+                previous_positions.get(posting["summonerName"]),
+                last_played is not None and last_played == freshest,
+                last_five,
+                last_played,
                 apex_omits_games_word=apex_omits_games_word,
             )
         )
-    return output_list, current_positions
+    return output_list, previous_positions, current_positions
 
 
 # ------------------------------------------------------------------ posting


### PR DESCRIPTION
Adds a relative 'Last played:' line to every board entry and fixes the 🚩 flag.

**Last played** — per entry, from the newest match_stats.game_start (same query as the last-5 squares on the solo board). Rendered as Discord relative markup (`<t:..:R>` → 'Last played: 3 hours ago'), client-side and viewer-local, so the message never needs reposting just for time passing. Omitted for players with no recorded games.

**Flag rework** — 🚩 was in-memory 'LP changed last cycle' state, which (a) got wiped by the hot reload after every deploy, (b) missed 0-LP demotion-shield losses, and (c) could sit stale for hours because the board only reposted on LP movement. Now the flag is derived from match data: it marks the entry/entries with the board-wide most recent game (duo/premade partners in the same match all flag, as before). Survives reloads, catches LP-less games.

**Repost gate** — boards now render every cycle and post iff the rendered blocks differ from the last posted board, so late-arriving match rows (stream ingest is ~5 min vs the 2-min LP poll) move the flag/squares/last-played within a cycle. LP-diff bookkeeping (history snapshots, streak ping, name checks) stays gated on rank changes exactly as before. One redundant repost on the first cycle after a reload.

**Arrows** — position arrows now diff against a baseline that only advances on an actual reshuffle, so they persist until the next reshuffle instead of vanishing on unrelated reposts.

Ranked 5s board (incl. the placements fallback) gets the same treatment. No schema changes; py_compile + ruff clean.