### PR TITLE
feat(awards): weekly awards ceremony + trophy cabinet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ DATABASE_URL=
 # Optional: pin the Ranked 5s league-v4 queueType once discovered
 # (see docs/riot-api-reference.md).
 # ranked5s_queue_type=
+
+# Optional: channel id for the weekly-awards trophy cabinet board.
+# Unset = cabinet posting disabled (the Monday ceremony in #general
+# still runs).
+# awards_channel_id=

--- a/Bot/cogs/heartbeat.py
+++ b/Bot/cogs/heartbeat.py
@@ -42,6 +42,10 @@ STREAM_STALE_AFTER = dt.timedelta(minutes=30)
 # tick is plausible under Gateway flap; three is conclusively stuck.
 STICKY_PANEL_STALE_AFTER = dt.timedelta(minutes=15)
 
+# 3× CHECK_MINUTES from cogs.weekly_awards (15 min scheduler loop). Same
+# rationale: one missed tick is Gateway flap, three is a frozen loop.
+WEEKLY_AWARDS_STALE_AFTER = dt.timedelta(minutes=45)
+
 
 class Heartbeat(commands.Cog):
     """Restart frozen @tasks.loop tasks by reloading their parent cog."""
@@ -86,6 +90,13 @@ class Heartbeat(commands.Cog):
             extension="cogs.ranked5s_table_updater",
             attr="post_ranks_5s_last_fired",
             stale_after=POST_RANKS_STALE_AFTER,
+            now=now,
+        )
+        await self._check_one(
+            cog_name="WeeklyAwards",
+            extension="cogs.weekly_awards",
+            attr="awards_tick_last_fired",
+            stale_after=WEEKLY_AWARDS_STALE_AFTER,
             now=now,
         )
 

--- a/Bot/cogs/weekly_awards.py
+++ b/Bot/cogs/weekly_awards.py
@@ -1,0 +1,274 @@
+"""Weekly awards ceremony + all-time trophy cabinet.
+
+Every Monday from 06:00 Europe/London the bot posts five awards into
+#general covering the calendar week that just ended (Monday 00:00 ->
+Monday 00:00 London wall time), aggregated per Discord user across all
+of their tracked league accounts. Winners land in the weekly_awards
+table; an all-time trophy cabinet board (optional awards_channel_id env,
+see utils/config.py) is wiped-and-reposted after each ceremony.
+
+The ceremony is fully silent: silent=True + AllowedMentions.none() on
+every send, winners mentioned as <@id> for the rendered name only —
+nobody gets pinged. #general is never wiped — plain sends, chunked under
+Discord's 2000-char cap via leaderboard.chunk_blocks.
+
+Scheduling is a 15-min @tasks.loop, idempotent across restarts and hot
+reloads: a tick only posts when the awarded week has no weekly_awards
+rows yet AND the bot_config marker hasn't seen it (the marker covers the
+pathological zero-winner week, which records no rows). Computation lives
+in utils/awards.py; this cog owns scheduling, posting and persistence.
+"""
+
+import datetime as dt
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+from main import MyDiscordBot
+from psycopg.types.json import Jsonb
+from utils import awards, config, db, leaderboard
+from utils.loop_restart import restart_loop_later
+
+# #general — same channel as the loss-streak ping (STREAK_PING_CHANNEL in
+# cogs/league_table_updater.py).
+CEREMONY_CHANNEL = 667751882260742167
+
+# How often the scheduler wakes up to check whether a ceremony is due.
+CHECK_MINUTES = 15
+
+# The ceremony fires on Mondays from this hour (Europe/London) onward.
+CEREMONY_HOUR = 6
+
+# bot_config key recording the last week_start a ceremony was posted for.
+MARKER_KEY = "weekly_awards_last_posted"
+
+
+class WeeklyAwards(commands.Cog):
+    def __init__(self, bot: MyDiscordBot):
+        self.bot = bot
+        self.bot.logging.info(f"{__name__} loaded")
+        self.awards_tick.start()
+        # Watchdog input, same contract as FetchFromRiot.post_ranks_last_fired
+        # (cogs/heartbeat.py reloads us if this goes stale).
+        self.awards_tick_last_fired: dt.datetime | None = None
+        # Log the missing-cabinet-channel notice once per cog instance,
+        # not once per ceremony (mirrors the Ranked 5s inert pattern).
+        self._warned_no_cabinet = False
+
+    def cog_unload(self) -> None:
+        # discord.py does NOT cancel @tasks.loop tasks on cog unload —
+        # without this, every hot reload (auto_reload / heartbeat) leaves
+        # the old instance's loop running next to the new one's.
+        self.awards_tick.cancel()
+
+    # ------------------------------------------------------------- channels
+
+    async def _get_channel(self, channel_id: int) -> discord.abc.Messageable | None:
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except discord.HTTPException as exc:
+                self.bot.logging.error(f"Awards channel {channel_id} unavailable: {exc!r}")
+                return None
+        return channel
+
+    # ---------------------------------------------------------- persistence
+
+    async def _already_posted(self, week_start: dt.date) -> bool:
+        """True when this week's ceremony already ran (restart/reload safe).
+
+        Primary check: any weekly_awards row for the week. The bot_config
+        marker backs it up for a week where every award skipped — no rows
+        get recorded, and without the marker the ceremony would repost
+        every 15 minutes all Monday.
+        """
+        row = await db.fetchone(
+            "SELECT 1 FROM weekly_awards WHERE week_start = %s LIMIT 1", (week_start,)
+        )
+        if row is not None:
+            return True
+        row = await db.fetchone("SELECT value FROM bot_config WHERE key = %s", (MARKER_KEY,))
+        # ISO dates compare correctly as strings.
+        return row is not None and row[0] >= week_start.isoformat()
+
+    async def _record_winners(self, week_start: dt.date, results: dict) -> None:
+        rows = [
+            (week_start, award, w.user_id, w.display_name, w.value, Jsonb(w.detail))
+            for award, winners in results.items()
+            for w in winners
+        ]
+        if rows:
+            await db.executemany(
+                "INSERT INTO weekly_awards "
+                "(week_start, award, discord_user_id, display_name, value, detail) "
+                "VALUES (%s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (week_start, award, discord_user_id) DO NOTHING",
+                rows,
+            )
+        await db.execute(
+            "INSERT INTO bot_config (key, value, updated_at) VALUES (%s, %s, now()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()",
+            (MARKER_KEY, week_start.isoformat()),
+        )
+
+    # ------------------------------------------------------------- ceremony
+
+    async def _run_ceremony(self, week_start: dt.datetime, week_end: dt.datetime) -> None:
+        channel = await self._get_channel(CEREMONY_CHANNEL)
+        if channel is None:
+            # Nothing recorded — the next tick retries the whole ceremony.
+            return
+
+        results = await awards.compute_all_awards(week_start, week_end)
+        blocks = awards.build_ceremony_blocks(week_start.date(), results)
+
+        self.bot.logging.info(f"Posting weekly awards for week of {week_start.date()}")
+        for message_text in leaderboard.chunk_blocks(blocks):
+            await channel.send(
+                message_text,
+                silent=True,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
+        await self._record_winners(week_start.date(), results)
+        await self.refresh_cabinet()
+
+    # -------------------------------------------------------------- cabinet
+
+    async def refresh_cabinet(self) -> bool:
+        """Re-render + wipe-and-post the trophy cabinet. False if skipped."""
+        channel_id = config.awards_channel_id()
+        if channel_id is None:
+            if not self._warned_no_cabinet:
+                self._warned_no_cabinet = True
+                self.bot.logging.info(
+                    "awards_channel_id not set — trophy cabinet posting disabled "
+                    "(the weekly ceremony still runs)"
+                )
+            return False
+        channel = await self._get_channel(channel_id)
+        if channel is None:
+            return False
+
+        row = await db.fetchone("SELECT MAX(week_start) FROM weekly_awards")
+        latest_week = row[0] if row else None
+        latest_rows: list[tuple] = []
+        if latest_week is not None:
+            # Fresh display names via users; the recorded display_name is
+            # the fallback for members who've since left.
+            latest_rows = await db.fetchall(
+                """SELECT wa.award, wa.discord_user_id,
+                        COALESCE(
+                            NULLIF(
+                                CASE
+                                    WHEN COALESCE(u.nickname, '') = '' THEN u.discord_tag
+                                    ELSE u.nickname
+                                END,
+                                ''),
+                            wa.display_name),
+                        wa.value, wa.detail
+                    FROM weekly_awards wa
+                        LEFT JOIN users u ON u.user_id = wa.discord_user_id
+                    WHERE wa.week_start = %s
+                    ORDER BY wa.id""",
+                (latest_week,),
+            )
+        count_rows = await db.fetchall(
+            """SELECT wa.award,
+                    COALESCE(
+                        NULLIF(
+                            CASE
+                                WHEN COALESCE(u.nickname, '') = '' THEN u.discord_tag
+                                ELSE u.nickname
+                            END,
+                            ''),
+                        MAX(wa.display_name)),
+                    COUNT(*)
+                FROM weekly_awards wa
+                    LEFT JOIN users u ON u.user_id = wa.discord_user_id
+                GROUP BY wa.award, wa.discord_user_id, u.nickname, u.discord_tag"""
+        )
+
+        blocks = awards.build_cabinet_blocks(latest_week, latest_rows, count_rows)
+        self.bot.logging.info("Posting weekly awards trophy cabinet")
+        await leaderboard.wipe_and_post(channel, blocks, self.bot.logging)
+        return True
+
+    # ----------------------------------------------------------------- loop
+
+    @tasks.loop(minutes=CHECK_MINUTES)
+    async def awards_tick(self):
+        await self.bot.wait_until_ready()
+        # Watchdog input: set on EVERY tick (including the six non-Monday
+        # days) so the heartbeat cog can tell "loop frozen" apart from
+        # "no ceremony due".
+        self.awards_tick_last_fired = dt.datetime.now()
+
+        now_london = dt.datetime.now(awards.LONDON)
+        if not (now_london.weekday() == 0 and now_london.hour >= CEREMONY_HOUR):
+            return
+        week_start, week_end = awards.previous_week_bounds(now_london)
+        if await self._already_posted(week_start.date()):
+            return
+        await self._run_ceremony(week_start, week_end)
+
+    @awards_tick.error
+    async def awards_tick_error(self, exc: BaseException) -> None:
+        """Auto-restart awards_tick on unhandled error.
+
+        Default @tasks.loop behaviour on exception is to log + stop the
+        loop, which would silently kill every future ceremony. The restart
+        must run detached — this callback executes inside the dying loop
+        task, where is_running() is still True (see utils/loop_restart.py).
+        """
+        self.bot.logging.error(f"awards_tick errored: {exc!r}, restarting in 60s")
+        restart_loop_later(
+            self.awards_tick,
+            name="awards_tick",
+            log=self.bot.logging,
+            still_active=lambda: self.bot.get_cog("WeeklyAwards") is self,
+        )
+
+    # ------------------------------------------------------------- commands
+
+    @app_commands.command(
+        name="awards_preview",
+        description="Preview this week's award standings so far (records nothing)",
+    )
+    async def awards_preview(self, ctx: discord.Interaction):
+        await ctx.response.defer(ephemeral=True)
+        now_london = dt.datetime.now(awards.LONDON)
+        week_start, _week_end = awards.week_bounds(now_london)
+        results = await awards.compute_all_awards(week_start, now_london)
+        header = (
+            f"\U0001f3c6 **Weekly Awards — preview** — week of "
+            f"<t:{awards.week_epoch(week_start.date())}:d> so far (nothing recorded)"
+        )
+        blocks = awards.build_ceremony_blocks(week_start.date(), results, header=header)
+        for message_text in leaderboard.chunk_blocks(blocks):
+            await ctx.followup.send(
+                message_text,
+                ephemeral=True,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
+    @app_commands.command(
+        name="refresh_awards_cabinet",
+        description="Re-render and repost the weekly awards trophy cabinet",
+    )
+    async def refresh_awards_cabinet(self, ctx: discord.Interaction):
+        await ctx.response.defer(ephemeral=True)
+        posted = await self.refresh_cabinet()
+        if posted:
+            await ctx.followup.send("Trophy cabinet refreshed", ephemeral=True)
+        else:
+            await ctx.followup.send(
+                "Cabinet not posted — set awards_channel_id in .env "
+                "(or the channel is unavailable)",
+                ephemeral=True,
+            )
+
+
+async def setup(bot: MyDiscordBot):
+    await bot.add_cog(WeeklyAwards(bot))

--- a/Bot/db/setup.postgres.sql
+++ b/Bot/db/setup.postgres.sql
@@ -126,3 +126,20 @@ create table if not exists bot_config (
     value TEXT not null,
     updated_at TIMESTAMPTZ not null default now()
 );
+
+-- Weekly awards ceremony winners (cogs/weekly_awards.py): one row per
+-- (week, award, winner) — ties write several rows. week_start is the
+-- Monday (Europe/London) the awarded week began. detail carries the
+-- award-specific evidence (scoreline, duo record, per-account LP deltas)
+-- so the trophy cabinet re-renders without recomputing old weeks.
+create table if not exists weekly_awards (
+    id BIGINT generated always as identity primary key,
+    week_start DATE not null,
+    award TEXT not null,
+    discord_user_id BIGINT not null,
+    display_name TEXT,
+    value NUMERIC,
+    detail JSONB,
+    created_at TIMESTAMPTZ not null default now(),
+    unique (week_start, award, discord_user_id)
+);

--- a/Bot/utils/awards.py
+++ b/Bot/utils/awards.py
@@ -1,0 +1,687 @@
+"""Weekly awards ceremony: computation core.
+
+Five awards computed over one calendar week (Monday 00:00 -> Monday 00:00,
+Europe/London wall time) from existing tables — match_stats for games,
+league_history for LP — aggregated per Discord user: a person's tracked
+league accounts sum together. Solo queue only (queue_id 420 /
+league_history.queue 'RANKED_SOLO_5x5').
+
+Layering: pure, deterministic functions do the math and the rendering;
+thin async wrappers own the SQL; cogs/weekly_awards.py owns scheduling,
+posting and persistence. Roast lines rotate deterministically on the ISO
+week number so consecutive weeks differ without any randomness.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from fractions import Fraction
+from zoneinfo import ZoneInfo
+
+from utils import db
+from utils.riot_client import RANKED_SOLO_QUEUE_ID
+
+LONDON = ZoneInfo("Europe/London")
+
+# league_history.queue tag for solo snapshots (mirrors SOLO_QUEUE in
+# cogs/league_table_updater.py — utils must not import cogs).
+SOLO_QUEUE = "RANKED_SOLO_5x5"
+
+# Award keys as stored in weekly_awards.award — stable, do not rename.
+LP_LOSS = "lp_loss"
+LP_CHAD = "lp_chad"
+PUSSY = "pussy_of_the_weak"
+DUO_LEECH = "duo_leech"
+INT = "int_of_the_week"
+
+AWARD_ORDER = (LP_LOSS, LP_CHAD, PUSSY, DUO_LEECH, INT)
+
+
+@dataclass(frozen=True)
+class AwardMeta:
+    emoji: str
+    title: str
+    roasts: tuple[str, ...]  # rotated by ISO week number, see roast_line
+    skip_line: str  # posted when the award has no winner
+
+
+AWARDS: dict[str, AwardMeta] = {
+    LP_LOSS: AwardMeta(
+        emoji="\U0001f4c9",  # chart decreasing
+        title="Biggest LP Loss Loser",
+        roasts=(
+            "Uninstall was right there.",
+            "The ladder called — it wants a restraining order.",
+            "Riot should be sending a welfare check.",
+            "That's not a loss streak, that's a lifestyle.",
+        ),
+        skip_line="Nobody lost net LP this week. Disgustingly competent.",
+    ),
+    LP_CHAD: AwardMeta(
+        emoji="\U0001f4c8",  # chart increasing
+        title="LP Chad of the Week",
+        roasts=(
+            "Leave some LP for the rest of us.",
+            "The ladder's dad now.",
+            "Built different, allegedly.",
+            "Somebody run an anticheat on this man.",
+        ),
+        skip_line="Nobody gained net LP this week. Group therapy is on Thursdays.",
+    ),
+    PUSSY: AwardMeta(
+        emoji="\U0001f408",  # cat
+        title="Pussy of the Weak",
+        roasts=(
+            "The queue button doesn't bite.",
+            "Ranked anxiety remains undefeated.",
+            "Hiding in ARAM doesn't count.",
+            "The grind waited. They never came.",
+        ),
+        skip_line="Everyone kept up their habit this week — no cowards detected. \U0001f44f",
+    ),
+    DUO_LEECH: AwardMeta(
+        emoji="\U0001f91d",  # handshake
+        title="Duo Leech",
+        roasts=(
+            "Solo queue, allegedly.",
+            "Can't queue alone, won't queue alone.",
+            "The duo carries, the leech collects.",
+            "Emotional support duo required at all times.",
+        ),
+        skip_line="No duo leeches this week — everyone queued like adults.",
+    ),
+    INT: AwardMeta(
+        emoji="\U0001f480",  # skull
+        title="Int of the Week",
+        roasts=(
+            "That's not inting, that's performance art.",
+            "Deaths bought in bulk this week.",
+            "Gray screen simulator: 100% completion.",
+            "Running it down with purpose and conviction.",
+        ),
+        skip_line="Nobody managed a proper int this week. Boring.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Winner:
+    """One winner of one award — ties produce several per award."""
+
+    user_id: int
+    display_name: str
+    value: float  # the number that condemns them (weekly_awards.value)
+    detail: dict  # award-specific evidence (weekly_awards.detail)
+
+
+# ----------------------------------------------------------------- weeks
+
+
+def week_bounds(now: dt.datetime) -> tuple[dt.datetime, dt.datetime]:
+    """[Monday 00:00, next Monday 00:00) London wall time containing ``now``.
+
+    Built with ``combine(date, 00:00, LONDON)`` rather than timedelta
+    arithmetic on an aware datetime so a DST transition inside the week
+    can't shift the boundary — London switches at 01:00 on a Sunday, so
+    Monday 00:00 itself is never ambiguous.
+    """
+    local = now.astimezone(LONDON)
+    monday = (local - dt.timedelta(days=local.weekday())).date()
+    return (
+        dt.datetime.combine(monday, dt.time(), tzinfo=LONDON),
+        dt.datetime.combine(monday + dt.timedelta(days=7), dt.time(), tzinfo=LONDON),
+    )
+
+
+def previous_week_bounds(now: dt.datetime) -> tuple[dt.datetime, dt.datetime]:
+    """Bounds of the calendar week that ended most recently before ``now``."""
+    start, _ = week_bounds(now)
+    monday = start.date()
+    return (
+        dt.datetime.combine(monday - dt.timedelta(days=7), dt.time(), tzinfo=LONDON),
+        start,
+    )
+
+
+def week_epoch(week_start: dt.date) -> int:
+    """Unix seconds of Monday 00:00 London for Discord <t:...:d> markup."""
+    return int(dt.datetime.combine(week_start, dt.time(), tzinfo=LONDON).timestamp())
+
+
+# ----------------------------------------------------------- LP scale
+
+
+_TIER_ORDER = ("Iron", "Bronze", "Silver", "Gold", "Platinum", "Emerald", "Diamond")
+_APEX_TIERS = ("Master", "Grandmaster", "Challenger")
+_DIVISION_OFFSET = {"IV": 0, "III": 1, "II": 2, "I": 3}
+_APEX_FLOOR = len(_TIER_ORDER) * 400  # top of Diamond I 100lp == Master 0lp
+
+
+def absolute_lp(tier: str, division: str | None, lp: int) -> int:
+    """(tier, division, lp) -> one absolute LP number. Iron IV 0lp = 0.
+
+    Each division is 100 LP (IV -> I within a tier), tiers stack 400
+    apart. Master/Grandmaster/Challenger share a single continuum above
+    Diamond: apex tiers have no divisions and apex "promotion" doesn't
+    reset LP, so all three map to ``2800 + lp`` (GM at 500lp and
+    Challenger at 500lp are the same height by construction).
+
+    Deliberately NOT Ranker._score — its adjustment_factor is a sort
+    hack, unusable as a difference scale. Raises ValueError on a tier or
+    division string it doesn't know so callers can skip bad rows.
+    """
+    tier_name = tier.title()
+    if tier_name in _APEX_TIERS:
+        return _APEX_FLOOR + int(lp)
+    try:
+        tier_index = _TIER_ORDER.index(tier_name)
+        division_offset = _DIVISION_OFFSET[(division or "").upper()]
+    except (ValueError, KeyError) as exc:
+        raise ValueError(f"unknown tier/division {tier!r} {division!r}") from exc
+    return tier_index * 400 + division_offset * 100 + int(lp)
+
+
+# --------------------------------------------------- pure award pickers
+
+
+def net_lp_deltas(
+    baseline_rows: list[tuple],
+    first_in_week_rows: list[tuple],
+    last_in_week_rows: list[tuple],
+) -> dict[int, dict]:
+    """Net weekly LP delta per Discord user, summed across their accounts.
+
+    All three row lists share the shape ``(puuid, discord_user_id,
+    display_name, league_username, tier, division, lp)`` with one row per
+    account (see fetch_lp_snapshot_rows). Per account: end = last snapshot
+    inside the week; start = latest snapshot at-or-before week start,
+    falling back to the earliest snapshot inside the week. Accounts with
+    no in-week snapshot contribute nothing — league_history only writes
+    on LP change, so no row means no movement. Accounts whose tier string
+    absolute_lp doesn't know are skipped rather than poisoning the sum.
+    """
+    baselines = {row[0]: row for row in baseline_rows}
+    firsts = {row[0]: row for row in first_in_week_rows}
+    per_user: dict[int, dict] = {}
+    for puuid, user_id, display_name, league_username, tier, division, lp in last_in_week_rows:
+        start = baselines.get(puuid) or firsts.get(puuid)
+        if start is None:
+            continue  # unreachable: a last-in-week row implies a first-in-week row
+        try:
+            delta = absolute_lp(tier, division, lp) - absolute_lp(start[4], start[5], start[6])
+        except ValueError:
+            continue
+        entry = per_user.setdefault(
+            user_id, {"display_name": display_name, "delta": 0, "per_account": {}}
+        )
+        entry["delta"] += delta
+        entry["per_account"][league_username] = delta
+    return per_user
+
+
+def pick_lp_extreme(per_user: dict[int, dict], *, gain: bool) -> list[Winner]:
+    """Largest net gain (``gain=True``) or net loss winner(s).
+
+    Only strictly-positive (resp. strictly-negative) net deltas compete;
+    a 0 net week competes for neither award.
+    """
+    sign = 1 if gain else -1
+    candidates = [(uid, e) for uid, e in sorted(per_user.items()) if sign * e["delta"] > 0]
+    if not candidates:
+        return []
+    best = max(sign * entry["delta"] for _, entry in candidates)
+    return [
+        Winner(
+            user_id=uid,
+            display_name=entry["display_name"],
+            value=float(entry["delta"]),
+            detail={"delta": entry["delta"], "per_account": entry["per_account"]},
+        )
+        for uid, entry in candidates
+        if sign * entry["delta"] == best
+    ]
+
+
+def pick_volume_collapse(rows: list[tuple]) -> list[Winner]:
+    """Biggest games-played collapse vs the player's own 4-week habit.
+
+    ``rows``: ``(discord_user_id, display_name, prior_4w_games,
+    this_week_games)`` per user. Baseline = prior_4w_games / 4; only users
+    with a baseline >= 5 games/week qualify, and only if this week came in
+    UNDER it. Winner = largest drop ratio (baseline - week) / baseline,
+    tie-broken by the higher baseline (the bigger habit fell further).
+    Exact Fraction arithmetic so ties are real ties, not float noise.
+    """
+    candidates = []
+    for user_id, display_name, prior_games, week_games in sorted(rows):
+        if prior_games < 20:  # baseline (prior/4) must be >= 5 games/week
+            continue
+        baseline = Fraction(prior_games, 4)
+        if week_games >= baseline:
+            continue
+        ratio = Fraction(prior_games - 4 * week_games, prior_games)  # (baseline-week)/baseline
+        candidates.append((ratio, baseline, user_id, display_name, week_games))
+    if not candidates:
+        return []
+    best = max((ratio, baseline) for ratio, baseline, *_ in candidates)
+    return [
+        Winner(
+            user_id=user_id,
+            display_name=display_name,
+            value=float(ratio),
+            detail={
+                "baseline": float(baseline),
+                "this_week": week_games,
+                "drop_pct": round(float(ratio) * 100),
+            },
+        )
+        for ratio, baseline, user_id, display_name, week_games in candidates
+        if (ratio, baseline) == best
+    ]
+
+
+def pick_duo_leech(rows: list[tuple]) -> list[Winner]:
+    """Highest duo-game fraction this week; min 5 games, min 2 duo games.
+
+    ``rows``: ``(discord_user_id, display_name, games, duo_games,
+    duo_wins, solo_wins)`` per user, duo as defined by fetch_duo_rows.
+    The detail keeps the duo-vs-solo records — the leech evidence.
+    """
+    candidates = []
+    for user_id, display_name, games, duo_games, duo_wins, solo_wins in sorted(rows):
+        if games < 5 or duo_games < 2:
+            continue
+        fraction = Fraction(duo_games, games)
+        candidates.append((fraction, user_id, display_name, games, duo_games, duo_wins, solo_wins))
+    if not candidates:
+        return []
+    best = max(fraction for fraction, *_ in candidates)
+    winners = []
+    for fraction, user_id, display_name, games, duo_games, duo_wins, solo_wins in candidates:
+        if fraction != best:
+            continue
+        solo_games = games - duo_games
+        winners.append(
+            Winner(
+                user_id=user_id,
+                display_name=display_name,
+                value=float(fraction),
+                detail={
+                    "games": games,
+                    "duo_games": duo_games,
+                    "duo_wins": duo_wins,
+                    "duo_losses": duo_games - duo_wins,
+                    "solo_wins": solo_wins,
+                    "solo_losses": solo_games - solo_wins,
+                },
+            )
+        )
+    return winners
+
+
+def pick_int(rows: list[tuple]) -> list[Winner]:
+    """Most deaths in a single game; ties broken by the worse (k+a)/d.
+
+    ``rows``: ``(discord_user_id, display_name, kills, deaths, assists,
+    champion, win, match_id)`` — one row per game. 0-death games can't
+    win (and an empty week returns [], letting the skip line run). A user
+    tying with two of their own games still gets one trophy.
+    """
+    games = [row for row in rows if row[3] > 0]
+    if not games:
+        return []
+
+    def badness(row: tuple) -> tuple:
+        _, _, kills, deaths, assists, *_ = row
+        return (deaths, -Fraction(kills + assists, deaths))
+
+    worst = max(badness(row) for row in games)
+    winners: list[Winner] = []
+    seen: set[int] = set()
+    for row in sorted(games):
+        if badness(row) != worst:
+            continue
+        user_id, display_name, kills, deaths, assists, champion, win, match_id = row
+        if user_id in seen:
+            continue
+        seen.add(user_id)
+        winners.append(
+            Winner(
+                user_id=user_id,
+                display_name=display_name,
+                value=float(deaths),
+                detail={
+                    "kills": kills,
+                    "deaths": deaths,
+                    "assists": assists,
+                    "champion": champion,
+                    "win": int(win),
+                    "match_id": match_id,
+                },
+            )
+        )
+    return winners
+
+
+# ----------------------------------------------------------- rendering
+
+
+def roast_line(award: str, week_start: dt.date) -> str:
+    """Deterministic roast rotation: indexed by ISO week number."""
+    meta = AWARDS[award]
+    return meta.roasts[week_start.isocalendar()[1] % len(meta.roasts)]
+
+
+def condemn_line(award: str, winner: Winner) -> str:
+    """The one-line number that condemns the winner, from their detail."""
+    detail = winner.detail
+    if award in (LP_LOSS, LP_CHAD):
+        line = f"Net **{detail['delta']:+d} LP** on the week"
+        # Per-account breakdown, but only when it adds information: at
+        # least two accounts actually moved (zero-delta accounts stay in
+        # the stored detail, just not in the post).
+        moved = {name: delta for name, delta in detail["per_account"].items() if delta}
+        if len(moved) > 1:
+            parts = " · ".join(f"{name} {delta:+d}" for name, delta in moved.items())
+            line += f" ({parts})"
+        return line + "."
+    if award == PUSSY:
+        week_games = detail["this_week"]
+        games_word = "game" if week_games == 1 else "games"
+        return (
+            f"**{week_games}** {games_word} vs a {detail['baseline']:g}-game/week habit "
+            f"(**-{detail['drop_pct']}%**)."
+        )
+    if award == DUO_LEECH:
+        return (
+            f"**{detail['duo_games']} of {detail['games']}** games duo'd — "
+            f"duo {detail['duo_wins']}W-{detail['duo_losses']}L "
+            f"vs solo {detail['solo_wins']}W-{detail['solo_losses']}L."
+        )
+    if award == INT:
+        result = "win" if detail["win"] else "loss"
+        return (
+            f"**{detail['kills']}/{detail['deaths']}/{detail['assists']}** "
+            f"on {detail['champion']} ({result})."
+        )
+    raise ValueError(f"unknown award {award!r}")
+
+
+def build_ceremony_blocks(
+    week_start: dt.date,
+    results: dict[str, list[Winner]],
+    header: str | None = None,
+) -> list[str]:
+    """Ceremony post as blocks for leaderboard.chunk_blocks.
+
+    One block per award: emoji + name, winner mention(s), the condemning
+    number, one roast. Joint winners share a block, one detail line each.
+    Every block ends with a newline so chunked messages get a blank line
+    between awards.
+    """
+    if header is None:
+        header = f"\U0001f3c6 **Weekly Awards** — week of <t:{week_epoch(week_start)}:d>"
+    blocks = [f"{header}\n"]
+    for award in AWARD_ORDER:
+        meta = AWARDS[award]
+        winners = results.get(award) or []
+        if not winners:
+            blocks.append(f"{meta.emoji} **{meta.title}** — no winner\n{meta.skip_line}\n")
+            continue
+        mentions = " & ".join(f"<@{winner.user_id}>" for winner in winners)
+        if len(winners) == 1:
+            body = condemn_line(award, winners[0])
+        else:
+            body = "\n".join(
+                f"{winner.display_name}: {condemn_line(award, winner)}" for winner in winners
+            )
+        blocks.append(
+            f"{meta.emoji} **{meta.title}** — {mentions}\n{body} {roast_line(award, week_start)}\n"
+        )
+    return blocks
+
+
+def cabinet_value(award: str, value, detail: dict | None) -> str:
+    """Compact value tag for a cabinet last-week line, e.g. '(-187 LP)'.
+
+    ``value`` arrives as Decimal from the numeric column; ``detail`` as a
+    dict from jsonb (defensively optional).
+    """
+    detail = detail or {}
+    if award in (LP_LOSS, LP_CHAD):
+        return f"{int(value):+d} LP"
+    if award == PUSSY:
+        drop = detail.get("drop_pct", round(float(value) * 100))
+        return f"-{drop}% volume"
+    if award == DUO_LEECH:
+        if "duo_games" in detail and "games" in detail:
+            return f"{detail['duo_games']}/{detail['games']} duo"
+        return f"{float(value):.0%} duo"
+    if award == INT:
+        if {"kills", "deaths", "assists"} <= detail.keys():
+            return f"{detail['kills']}/{detail['deaths']}/{detail['assists']}"
+        return f"{int(value)} deaths"
+    return str(value)
+
+
+def build_cabinet_blocks(
+    latest_week: dt.date | None,
+    latest_rows: list[tuple],
+    count_rows: list[tuple],
+) -> list[str]:
+    """Trophy cabinet board blocks for leaderboard.wipe_and_post.
+
+    ``latest_rows``: ``(award, discord_user_id, display_name, value,
+    detail)`` for the most recent recorded week; ``count_rows``:
+    ``(award, display_name, titles)`` all-time. Awards keep AWARD_ORDER;
+    within an award, most titles first, then name.
+    """
+    header = "\U0001f3c6 **Trophy Cabinet** — weekly awards, all time\n"
+    if latest_week is None:
+        return [header, "No ceremonies recorded yet — the first one posts Monday morning."]
+
+    last_lines = [f"**Last week** (<t:{week_epoch(latest_week)}:d>):"]
+    latest_by_award: dict[str, list[tuple]] = {}
+    for award, user_id, name, value, detail in latest_rows:
+        latest_by_award.setdefault(award, []).append((user_id, name, value, detail))
+    for award in AWARD_ORDER:
+        rows = latest_by_award.get(award)
+        if not rows:
+            continue
+        meta = AWARDS[award]
+        mentions = " & ".join(f"<@{user_id}>" for user_id, *_ in rows)
+        last_lines.append(
+            f"{meta.emoji} {meta.title} — {mentions} ({cabinet_value(award, rows[0][2], rows[0][3])})"
+        )
+
+    count_lines = ["**All-time titles**"]
+    counts_by_award: dict[str, list[tuple]] = {}
+    for award, name, titles in count_rows:
+        counts_by_award.setdefault(award, []).append((titles, name or ""))
+    for award in AWARD_ORDER:
+        entries = counts_by_award.get(award)
+        if not entries:
+            continue
+        entries.sort(key=lambda pair: (-pair[0], pair[1]))
+        joined = " · ".join(f"{titles}× {name}" for titles, name in entries)
+        count_lines.append(f"{AWARDS[award].emoji} {AWARDS[award].title}: {joined}")
+
+    return [header, "\n".join(last_lines) + "\n", "\n".join(count_lines)]
+
+
+# -------------------------------------------------------- SQL wrappers
+
+
+# One row per tracked account, mapped to its Discord user + display name.
+# DISTINCT ON (puuid): league_players is keyed by the legacy leagueid, so a
+# renamed account could leave two rows with the same puuid — joining both
+# would double-count games. Display name falls back to league_username when
+# the users row is missing/blank.
+_TRACKED_CTE = """
+    tracked AS (
+        SELECT DISTINCT ON (lp.puuid)
+               lp.puuid,
+               lp.discord_user_id,
+               lp.league_username,
+               COALESCE(
+                   NULLIF(
+                       CASE
+                           WHEN COALESCE(u.nickname, '') = '' THEN u.discord_tag
+                           ELSE u.nickname
+                       END,
+                       ''),
+                   lp.league_username) AS display_name
+        FROM league_players lp
+            LEFT JOIN users u ON u.user_id = lp.discord_user_id
+        WHERE lp.puuid IS NOT NULL
+        ORDER BY lp.puuid
+    )
+"""
+
+
+def _snapshot_query(where: str, order: str) -> str:
+    return (
+        "WITH "
+        + _TRACKED_CTE
+        + """
+        SELECT DISTINCT ON (lh.puuid)
+               lh.puuid, t.discord_user_id, t.display_name, t.league_username,
+               lh.tier, lh.division, lh.lp
+        FROM league_history lh
+            JOIN tracked t ON t.puuid = lh.puuid
+        WHERE lh.queue = %(queue)s
+          AND lh.tier IS NOT NULL AND lh.lp IS NOT NULL
+          AND """
+        + where
+        + " ORDER BY lh.puuid, "
+        + order
+    )
+
+
+async def fetch_lp_snapshot_rows(
+    week_start: dt.datetime, week_end: dt.datetime
+) -> tuple[list[tuple], list[tuple], list[tuple]]:
+    """(baseline, first-in-week, last-in-week) solo snapshot rows.
+
+    One row per account each: baseline = latest snapshot at-or-before
+    week_start, the other two bracket the week. Rows keyed by real puuid
+    only — the pre-2024 legacy-key rows can't matter inside a recent
+    weekly window.
+    """
+    params = {"queue": SOLO_QUEUE, "start": week_start, "end": week_end}
+    baseline = await db.fetchall(
+        _snapshot_query("lh.timestamp <= %(start)s", "lh.timestamp DESC, lh.id DESC"),
+        params,
+    )
+    in_week = "lh.timestamp >= %(start)s AND lh.timestamp < %(end)s"
+    first = await db.fetchall(
+        _snapshot_query(in_week, "lh.timestamp ASC, lh.id ASC"),
+        params,
+    )
+    last = await db.fetchall(
+        _snapshot_query(in_week, "lh.timestamp DESC, lh.id DESC"),
+        params,
+    )
+    return baseline, first, last
+
+
+async def fetch_volume_rows(week_start: dt.datetime, week_end: dt.datetime) -> list[tuple]:
+    """(discord_user_id, display_name, prior_4w_games, this_week_games).
+
+    Prior window = the 4 full weeks before the award week. Users with
+    prior games but zero this week ARE included (that's the award); users
+    who only appeared this week get prior_games=0 and can't qualify.
+    """
+    prior_start = week_start - dt.timedelta(days=28)
+    return await db.fetchall(
+        "WITH "
+        + _TRACKED_CTE
+        + """
+        SELECT t.discord_user_id,
+               MIN(t.display_name),
+               COUNT(*) FILTER (WHERE ms.game_start < %(start)s) AS prior_games,
+               COUNT(*) FILTER (WHERE ms.game_start >= %(start)s) AS week_games
+        FROM match_stats ms
+            JOIN tracked t ON t.puuid = ms.puuid
+        WHERE ms.queue_id = %(queue_id)s
+          AND ms.game_start >= %(prior_start)s AND ms.game_start < %(end)s
+        GROUP BY t.discord_user_id""",
+        {
+            "queue_id": RANKED_SOLO_QUEUE_ID,
+            "prior_start": prior_start,
+            "start": week_start,
+            "end": week_end,
+        },
+    )
+
+
+async def fetch_duo_rows(week_start: dt.datetime, week_end: dt.datetime) -> list[tuple]:
+    """(discord_user_id, display_name, games, duo_games, duo_wins, solo_wins).
+
+    Duo = another tracked player has a match_stats row for the same match
+    on the same team (match_stats holds only tracked players) — the same
+    EXISTS pattern as FetchFromRiot.get_last_five_games. NULL team_id
+    (rows predating the column) never counts as duo.
+    """
+    return await db.fetchall(
+        "WITH "
+        + _TRACKED_CTE
+        + """,
+        games AS (
+            SELECT ms.puuid, ms.win,
+                   EXISTS (
+                       SELECT 1 FROM match_stats o
+                       WHERE o.match_id = ms.match_id
+                         AND o.team_id = ms.team_id
+                         AND o.puuid <> ms.puuid
+                   ) AS duo
+            FROM match_stats ms
+            WHERE ms.queue_id = %(queue_id)s
+              AND ms.game_start >= %(start)s AND ms.game_start < %(end)s
+        )
+        SELECT t.discord_user_id,
+               MIN(t.display_name),
+               COUNT(*) AS games,
+               COUNT(*) FILTER (WHERE g.duo) AS duo_games,
+               COUNT(*) FILTER (WHERE g.duo AND g.win = 1) AS duo_wins,
+               COUNT(*) FILTER (WHERE NOT g.duo AND g.win = 1) AS solo_wins
+        FROM games g
+            JOIN tracked t ON t.puuid = g.puuid
+        GROUP BY t.discord_user_id""",
+        {"queue_id": RANKED_SOLO_QUEUE_ID, "start": week_start, "end": week_end},
+    )
+
+
+async def fetch_int_rows(week_start: dt.datetime, week_end: dt.datetime) -> list[tuple]:
+    """(discord_user_id, display_name, kills, deaths, assists, champion,
+    win, match_id) — one row per solo game this week with >= 1 death."""
+    return await db.fetchall(
+        "WITH "
+        + _TRACKED_CTE
+        + """
+        SELECT t.discord_user_id, t.display_name,
+               ms.kills, ms.deaths, ms.assists, ms.champion, ms.win, ms.match_id
+        FROM match_stats ms
+            JOIN tracked t ON t.puuid = ms.puuid
+        WHERE ms.queue_id = %(queue_id)s
+          AND ms.game_start >= %(start)s AND ms.game_start < %(end)s
+          AND ms.deaths > 0
+        ORDER BY ms.deaths DESC""",
+        {"queue_id": RANKED_SOLO_QUEUE_ID, "start": week_start, "end": week_end},
+    )
+
+
+async def compute_all_awards(
+    week_start: dt.datetime, week_end: dt.datetime
+) -> dict[str, list[Winner]]:
+    """All five awards for [week_start, week_end) — empty list = skipped."""
+    baseline, first, last = await fetch_lp_snapshot_rows(week_start, week_end)
+    deltas = net_lp_deltas(baseline, first, last)
+    return {
+        LP_LOSS: pick_lp_extreme(deltas, gain=False),
+        LP_CHAD: pick_lp_extreme(deltas, gain=True),
+        PUSSY: pick_volume_collapse(await fetch_volume_rows(week_start, week_end)),
+        DUO_LEECH: pick_duo_leech(await fetch_duo_rows(week_start, week_end)),
+        INT: pick_int(await fetch_int_rows(week_start, week_end)),
+    }

--- a/Bot/utils/config.py
+++ b/Bot/utils/config.py
@@ -56,6 +56,17 @@ def riot_api_key() -> str | None:
     return os.environ.get("riot_key")
 
 
+def awards_channel_id() -> int | None:
+    """Channel for the weekly-awards trophy cabinet board.
+
+    None (unset) disables cabinet posting — the Monday ceremony in
+    #general still runs; cogs/weekly_awards.py logs the skip once per
+    cog instance (same inert pattern as the Ranked 5s board channel).
+    """
+    value = os.environ.get("awards_channel_id")
+    return int(value) if value else None
+
+
 def ranked5s_queue_type() -> str | None:
     """league-v4 queueType for Ranked 5s entries.
 

--- a/scripts/migrate_add_weekly_awards.py
+++ b/scripts/migrate_add_weekly_awards.py
@@ -1,0 +1,91 @@
+"""Idempotent migration: create the weekly_awards table.
+
+The weekly awards ceremony (cogs/weekly_awards.py) records each week's
+winners here; the trophy cabinet board renders all-time title counts from
+it. main.py auto-applies Bot/db/setup.postgres.sql on every boot, but
+deploys hot-reload cogs without restarting the process — this script gets
+the table onto the live DB without waiting for the next full restart.
+
+The DDL below is kept identical to the weekly_awards block in
+Bot/db/setup.postgres.sql.
+
+Usage:
+    python3 scripts/migrate_add_weekly_awards.py [--database-url DSN] [--dry-run]
+
+DSN default: the DATABASE_URL env var — same source as utils/config.py,
+no baked-in credential fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+
+# DSN comes from --database-url or the DATABASE_URL env var — like
+# utils/config.py, no baked-in credential fallback.
+DEFAULT_DSN = os.environ.get("DATABASE_URL")
+
+CREATE_TABLE_SQL = """
+create table if not exists weekly_awards (
+    id BIGINT generated always as identity primary key,
+    week_start DATE not null,
+    award TEXT not null,
+    discord_user_id BIGINT not null,
+    display_name TEXT,
+    value NUMERIC,
+    detail JSONB,
+    created_at TIMESTAMPTZ not null default now(),
+    unique (week_start, award, discord_user_id)
+)
+"""
+
+
+def migrate(dsn: str, dry_run: bool = False) -> int:
+    with psycopg.connect(dsn) as conn:
+        exists = conn.execute("SELECT to_regclass('weekly_awards')").fetchone()[0]
+        if exists is not None:
+            print("[migrate] weekly_awards table already present — nothing to do")
+            return 0
+
+        if dry_run:
+            print("[migrate] DRY RUN — would CREATE TABLE weekly_awards (+ unique constraint)")
+            return 0
+
+        print("[migrate] creating weekly_awards table...")
+        conn.execute(CREATE_TABLE_SQL)
+        conn.commit()
+
+        check = conn.execute("SELECT to_regclass('weekly_awards')").fetchone()[0]
+        if check is None:
+            print("[migrate] ERROR: weekly_awards still missing after CREATE")
+            return 2
+
+        print("[migrate] done. The weekly_awards cog can now record ceremonies.")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--database-url",
+        default=DEFAULT_DSN,
+        help="Postgres DSN (default: the DATABASE_URL env var; required one way or the other)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report whether the table exists, don't modify the DB",
+    )
+    args = parser.parse_args()
+    if not args.database_url:
+        parser.error("no DSN: pass --database-url or set the DATABASE_URL env var")
+    return migrate(args.database_url, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Monday 6am (Europe/London) ceremony in #general covering the calendar week just ended, plus an all-time trophy cabinet board.

**Five awards**, solo queue, aggregated per Discord user across all their tracked accounts:
- 📉 Biggest LP Loss Loser / 📈 LP Chad — net weekly LP delta from league_history snapshots, converted to an absolute LP scale (divisions = 100, tiers stack, Master+ share one continuum) so demotions count properly.
- 🐈 Pussy of the Weak — biggest games-played collapse vs the player's own trailing-4-week baseline (baseline ≥5 games/week to qualify).
- 🤝 Duo Leech — highest duo fraction (min 5 games, 2 duo), with duo-vs-solo records as evidence.
- 💀 Int of the Week — most deaths in one game (tie-break: worse KDA), scoreline + champion.

**Mechanics:** 15-min scheduler loop, restart/hot-reload-idempotent (weekly_awards rows + a bot_config marker for zero-winner weeks); fully silent posts (no pings, #general never wiped); deterministic weekly roast rotation; joint winners on exact-fraction ties; loop error auto-restart + heartbeat watchdog.

**New:** weekly_awards table (setup.postgres.sql + idempotent scripts/migrate_add_weekly_awards.py), utils/awards.py (pure computation + thin SQL), cogs/weekly_awards.py, awards_channel_id config for the cabinet (unset = cabinet dormant, ceremony unaffected), /awards_preview (ephemeral week-so-far standings, records nothing) and /refresh_awards_cabinet.

Needs a full restart after merge (new files + schema). First ceremony: Monday 2026-08-03.