### PR TITLE
feat(logging): bot-wide log cleanup — destinations, boot state, signal over spam

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -58,15 +58,16 @@ class FetchFromRiot(commands.Cog):
     async def fetch_users_rank(self, users):
         users_ranks = {}
         seen: set[str] = set()
+        failed = 0
 
         # League-entries uses platform routing (euw1), not regional (europe).
         for puuid, name, user_id in users:
             if puuid in seen:
                 continue
             seen.add(puuid)
-            self.bot.logging.info(f"Fetching rank for: {name}")
             user_rank = await get_league_entries(puuid)
             if user_rank is None:
+                failed += 1
                 self.bot.logging.error(f"Failed to fetch rank for {name}")
                 continue
 
@@ -89,6 +90,13 @@ class FetchFromRiot(commands.Cog):
             else:
                 fivev5 = []
 
+        # One DEBUG summary per cycle replaces the old per-account INFO
+        # line (~14 lines every 2 minutes). Failures still log per account
+        # at ERROR above; loop liveness is the heartbeat cog's job.
+        self.bot.logging.debug(
+            f"Rank fetch cycle: {len(seen) - failed}/{len(seen)} accounts fetched, "
+            f"{len(users_ranks)} on board"
+        )
         return users_ranks
 
     # @tasks.loop(seconds=30)
@@ -164,6 +172,10 @@ class FetchFromRiot(commands.Cog):
         extra = ""
         if games > 0 and deaths > 0 and (kills / deaths) < 1.0:
             extra = f" {kills}/{deaths}"
+        self.bot.logging.info(
+            f"Streak ping: user {user_id} on a {streak}-loss streak -> "
+            f"#general ({STREAK_PING_CHANNEL})"
+        )
         # \U0001FAF5 = pointing at viewer, \U0001F602 = face with tears of joy
         await channel.send(f"\U0001faf5\U0001f602 <@{user_id}>{extra}")
 
@@ -215,7 +227,13 @@ class FetchFromRiot(commands.Cog):
                         self.ranked_dict[user]["leaguePoints"]
                         != self.previous_ranks[user]["leaguePoints"]
                     ):
-                        print(f"{user} updated", flush=True)
+                        old = self.previous_ranks[user]
+                        new = self.ranked_dict[user]
+                        self.bot.logging.info(
+                            f"LP change: {user} "
+                            f"{old['tier']} {old['rank']} {old['leaguePoints']}lp -> "
+                            f"{new['tier']} {new['rank']} {new['leaguePoints']}lp"
+                        )
                         await self.update_table(user, self.ranked_dict[user])
                         updated_users.append(user)
 
@@ -364,14 +382,13 @@ class FetchFromRiot(commands.Cog):
 
     # Needs updating to grab last match from the table
     async def update_table(self, user, user_stats_dict):
-        # Keeps this board's historical logging/except shape (including the
-        # harmless "Exception as list index out of range" info line on a
-        # player's first-ever insert) around the shared history helpers.
+        # Keeps this board's historical except shape (a player's first-ever
+        # insert has no prior row and IndexErrors the W/L compare) around
+        # the shared history helpers.
         try:
-            self.bot.logging.info(f"updating table, logging {user_stats_dict}")
             last_values = await leaderboard.latest_history_wl(user_stats_dict["puuid"], SOLO_QUEUE)
         except Exception as e:
-            self.bot.logging.error(f"Failed to update table with error: {e}")
+            self.bot.logging.error(f"Failed to read history for {user}: {e!r}")
             return
         try:
             if last_values[0] == (
@@ -379,9 +396,15 @@ class FetchFromRiot(commands.Cog):
                 user_stats_dict["losses"],
             ):
                 return
-        except Exception as e:
-            self.bot.logging.info(f"Exception as {e}")
+        except Exception:
+            self.bot.logging.info(f"No prior history for {user} — first snapshot")
 
+        self.bot.logging.info(
+            f"History snapshot: {user} "
+            f"{user_stats_dict['tier']} {user_stats_dict['rank']} "
+            f"{user_stats_dict['leaguePoints']}lp "
+            f"{user_stats_dict['wins']}W/{user_stats_dict['losses']}L"
+        )
         await leaderboard.insert_history_snapshot(user_stats_dict, SOLO_QUEUE)
         return
 

--- a/Bot/cogs/ranked_graphing.py
+++ b/Bot/cogs/ranked_graphing.py
@@ -42,7 +42,6 @@ class LeagueGraphs(commands.Cog):
             "SELECT leagueId FROM league_players WHERE league_username = %s",
             (league_name,),
         )
-        print(summonerid)
         if not summonerid:
             await ctx.response.send_message(f"{league_name} does not exist in the database")
             return

--- a/Bot/cogs/weekly_awards.py
+++ b/Bot/cogs/weekly_awards.py
@@ -47,6 +47,14 @@ class WeeklyAwards(commands.Cog):
     def __init__(self, bot: MyDiscordBot):
         self.bot = bot
         self.bot.logging.info(f"{__name__} loaded")
+        # Log the live env value on every (re)load: env vars are frozen at
+        # container creation, so a .env edit followed by a plain restart
+        # leaves the old value running — this line is how you catch it.
+        cabinet_id = config.awards_channel_id()
+        self.bot.logging.info(
+            "Trophy cabinet channel (awards_channel_id env): "
+            + (str(cabinet_id) if cabinet_id else "not set — cabinet posting disabled")
+        )
         self.awards_tick.start()
         # Watchdog input, same contract as FetchFromRiot.post_ranks_last_fired
         # (cogs/heartbeat.py reloads us if this goes stale).
@@ -54,6 +62,9 @@ class WeeklyAwards(commands.Cog):
         # Log the missing-cabinet-channel notice once per cog instance,
         # not once per ceremony (mirrors the Ranked 5s inert pattern).
         self._warned_no_cabinet = False
+        # Week whose already-posted skip has been logged — once per week,
+        # not every 15-minute tick all Monday.
+        self._skip_logged_week: dt.date | None = None
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
@@ -111,6 +122,10 @@ class WeeklyAwards(commands.Cog):
             "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()",
             (MARKER_KEY, week_start.isoformat()),
         )
+        self.bot.logging.info(
+            f"Recorded {len(rows)} weekly award winner(s) for week of {week_start}; "
+            f"{MARKER_KEY} -> {week_start.isoformat()}"
+        )
 
     # ------------------------------------------------------------- ceremony
 
@@ -123,7 +138,10 @@ class WeeklyAwards(commands.Cog):
         results = await awards.compute_all_awards(week_start, week_end)
         blocks = awards.build_ceremony_blocks(week_start.date(), results)
 
-        self.bot.logging.info(f"Posting weekly awards for week of {week_start.date()}")
+        self.bot.logging.info(
+            f"Posting weekly awards for week of {week_start.date()} "
+            f"to #{getattr(channel, 'name', '?')} ({CEREMONY_CHANNEL})"
+        )
         for message_text in leaderboard.chunk_blocks(blocks):
             await channel.send(
                 message_text,
@@ -191,7 +209,11 @@ class WeeklyAwards(commands.Cog):
         )
 
         blocks = awards.build_cabinet_blocks(latest_week, latest_rows, count_rows)
-        self.bot.logging.info("Posting weekly awards trophy cabinet")
+        self.bot.logging.info(
+            f"Posting weekly awards trophy cabinet to #{getattr(channel, 'name', '?')} "
+            f"({channel_id}) — latest week {latest_week}: {len(latest_rows)} row(s), "
+            f"all-time: {len(count_rows)} row(s)"
+        )
         await leaderboard.wipe_and_post(channel, blocks, self.bot.logging)
         return True
 
@@ -210,6 +232,13 @@ class WeeklyAwards(commands.Cog):
             return
         week_start, week_end = awards.previous_week_bounds(now_london)
         if await self._already_posted(week_start.date()):
+            if self._skip_logged_week != week_start.date():
+                self._skip_logged_week = week_start.date()
+                self.bot.logging.info(
+                    f"Weekly awards for week of {week_start.date()} already posted — "
+                    "ceremony skipped (the cabinet reposts only after a ceremony or "
+                    "/refresh_awards_cabinet)"
+                )
             return
         await self._run_ceremony(week_start, week_end)
 

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -22,11 +22,11 @@ class MyDiscordBot(Bot):
         self.guildid = serverid
 
         riot_key = config.riot_api_key()
-        # Log API key info (first/last few chars only for security). All
-        # Riot calls go through utils/riot_client (shared rate budget).
+        # Presence only — no fragment of the key belongs in logs (CodeQL
+        # clear-text-logging). All Riot calls go through utils/riot_client
+        # (shared rate budget), which errors per-request on a bad key.
         if riot_key:
-            key_preview = f"{riot_key[:10]}...{riot_key[-4:]}" if len(riot_key) > 14 else "***"
-            logging.getLogger().info(f"Riot API key loaded: {key_preview}")
+            logging.getLogger().info("Riot API key loaded")
         else:
             logging.getLogger().warning(
                 "Riot API key not found in environment — Riot fetches will fail"

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -26,14 +26,15 @@ class MyDiscordBot(Bot):
         # Riot calls go through utils/riot_client (shared rate budget).
         if riot_key:
             key_preview = f"{riot_key[:10]}...{riot_key[-4:]}" if len(riot_key) > 14 else "***"
-            print(f"Riot API Key loaded: {key_preview}")
+            logging.getLogger().info(f"Riot API key loaded: {key_preview}")
         else:
-            print("WARNING: Riot API Key not found in environment variables!")
+            logging.getLogger().warning(
+                "Riot API key not found in environment — Riot fetches will fail"
+            )
 
         self.logging: logging.Logger = None
 
     async def setup_hook(self) -> None:
-        discord.utils.setup_logging()
         self.logging = logging.getLogger()
 
         for file in glob.glob("./cogs/*.py"):
@@ -42,7 +43,6 @@ class MyDiscordBot(Bot):
             await self.load_extension(f"cogs.{cog_name}")
 
     async def sync_discord(self) -> None:
-        print("Syncing users")
         guild = await self.fetch_guild(self.guildid)
         # Drain the Discord API iterators BEFORE touching the pool so no
         # pooled connection (max 5) sits pinned across paginated network
@@ -71,6 +71,7 @@ class MyDiscordBot(Bot):
                 if str(channel.type) != "category"
             ],
         )
+        self.logging.info(f"Synced {len(members)} members and {len(channels)} channels")
         return
 
     async def on_connect(self) -> None:
@@ -89,11 +90,17 @@ class MyDiscordBot(Bot):
 
 
 async def main(my_token: str) -> None:
+    # Root logging must exist before anything else runs — setup_hook is
+    # too late for boot-time lines (pool open, schema apply, key check).
+    # setup_hook must NOT call setup_logging again: it appends a second
+    # handler and every line doubles.
+    discord.utils.setup_logging()
+
     # Apply ./db/setup.postgres.sql on every boot. Safe — every statement
     # uses CREATE TABLE/INDEX IF NOT EXISTS, so this is a no-op when the
     # schema is already current.
     await db.apply_schema("./db/setup.postgres.sql")
-    print("Database schema applied")
+    logging.getLogger().info("Database schema applied")
 
     server_id = config.guild_id()
 

--- a/Bot/utils/db.py
+++ b/Bot/utils/db.py
@@ -16,10 +16,14 @@ Postgres notes for query authors:
 
 from __future__ import annotations
 
+import logging
+import re
 from contextlib import asynccontextmanager
 
 from psycopg_pool import AsyncConnectionPool
 from utils import config
+
+log = logging.getLogger(__name__)
 
 # Survive auto_reload's importlib.reload of utils modules: re-executing this
 # module body must not orphan a live pool (leaked connections would pile up
@@ -37,6 +41,10 @@ async def get_pool() -> AsyncConnectionPool:
         pool = AsyncConnectionPool(dsn(), min_size=1, max_size=5, open=False)
         await pool.open(wait=True, timeout=30.0)
         _pool = pool
+        # Credentials stripped: "postgresql://user:pass@host/db" logs as
+        # "postgresql://host/db". One line per process answers "which
+        # database is this bot actually on".
+        log.info(f"Postgres pool opened: {re.sub(r'//[^@/]*@', '//', dsn())}")
     return _pool
 
 

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -368,16 +368,35 @@ async def wipe_and_post(channel, content, log) -> None:
     a 400 after the wipe, leaving the channel empty. Boards are ping-free:
     silent sends, no mentions resolved. Empty content still wipes but
     posts nothing.
+
+    Every call logs the target channel (name + id) and the wipe/post
+    counts: boards land in env- or config-selected channels, and a stale
+    channel value is indistinguishable from success without the id in
+    the log.
     """
+    target = f"#{getattr(channel, 'name', '?')} ({getattr(channel, 'id', '?')})"
     blocks = [content] if isinstance(content, str) else [b for b in content if b]
+    deleted = 0
     try:
         async for message in channel.history():
             await message.delete()
+            deleted += 1
     except discord.errors.Forbidden:
-        log.warning("Missing permissions to delete messages, skipping cleanup")
-    for message_text in chunk_blocks(blocks):
-        await channel.send(
-            message_text,
-            silent=True,
-            allowed_mentions=discord.AllowedMentions.none(),
-        )
+        log.warning(f"Missing permissions to delete messages in {target}, skipping cleanup")
+    sent = 0
+    messages = chunk_blocks(blocks)
+    for message_text in messages:
+        try:
+            await channel.send(
+                message_text,
+                silent=True,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.HTTPException as exc:
+            log.error(
+                f"Board send to {target} failed on message {sent + 1} of "
+                f"{len(messages)} ({len(message_text)} chars): {exc!r}"
+            )
+            raise
+        sent += 1
+    log.info(f"Board refresh in {target}: wiped {deleted}, posted {sent} message(s)")

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -85,7 +85,13 @@ async def _wait_for_slot() -> None:
                 return
 
         # Release the lock while sleeping so other coroutines can re-check.
-        log.debug(f"Riot rate limit reached, waiting {wait:.2f}s")
+        # Long waits get INFO: sustained budget contention is what froze
+        # post_ranks during the position backfill, and DEBUG lines are
+        # invisible at the prod log level.
+        if wait > 5.0:
+            log.info(f"Riot budget contended: waiting {wait:.1f}s for a slot")
+        else:
+            log.debug(f"Riot rate limit reached, waiting {wait:.2f}s")
         await asyncio.sleep(wait)
 
 
@@ -130,6 +136,7 @@ async def _get_json(url: str, params: dict | None = None) -> tuple[int, list | d
                 continue
             return (0, None)
 
+    log.error(f"Riot 429 retries exhausted for {url}")
     return (429, None)
 
 


### PR DESCRIPTION
## Motivation

Two incidents this week were invisible in the logs: the trophy cabinet posting to a stale channel id (`Posting weekly awards trophy cabinet` with no destination), and — historically — the position-backfill rate-limit freeze and the 2000-char-cap empty board. Meanwhile ~90% of log volume was `Fetching rank for: X` repeated 14× every 2 minutes. This PR makes the logs answer the questions we actually ask of them, and stops the spam.

## Changes (all logging-only, no behavior changes)

**Boards — `utils/leaderboard.py`**
- `wipe_and_post` logs every refresh with target channel (name + id) and wiped/posted counts; failed sends log which chunk died and its char length before re-raising; the missing-permission warning names the channel

**Weekly awards — `cogs/weekly_awards.py`**
- Cog load logs the `awards_channel_id` the process actually has (catches the .env-edit + `docker restart` trap immediately)
- Ceremony/cabinet posts name their destination channel; cabinet adds row counts; recording winners logs count + marker; already-posted Monday ticks log the skip once per week

**Boot — `main.py`, `utils/db.py`**
- `setup_logging()` moves to `main()` so boot lines (schema apply, Riot key check, pool open) are real log lines, not `print()`s; `setup_hook` no longer calls it (double handler = every line twice)
- Postgres pool logs its credential-stripped DSN once per process — "which database is this bot on"
- `sync_discord` logs member/channel counts

**Riot client — `utils/riot_client.py`**
- Waits >5s for a rate-limit slot log at INFO (sustained contention froze `post_ranks` during the position backfill; the DEBUG line was invisible in prod)
- Exhausting all 429 retries logs at ERROR before returning failure

**Solo board — `cogs/league_table_updater.py`, `cogs/ranked_graphing.py`**
- Per-account `Fetching rank for` INFO spam removed (~10k lines/day); replaced by a per-cycle DEBUG summary; per-account failures stay at ERROR
- `print('user updated')` → proper LP-change line with tier/div/LP before → after
- `update_table` stops dumping the raw stats dict; logs a compact history-snapshot line; the bare `Exception as list index out of range` line becomes `No prior history — first snapshot`
- Streak pings (outward-facing send, previously silent) log user, streak length and channel

## Untouched on purpose
`heartbeat`, `auto_reload`, `backfill`, `sync`, `match_analysis` already log the right things at sane volumes.