### PR TITLE
feat(seasons): automated season handling — detection, seasons table, awards guard, graph window

### DIFF
--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -5,7 +5,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from main import MyDiscordBot
-from utils import db, leaderboard
+from utils import db, leaderboard, seasons
 from utils.loop_restart import restart_loop_later
 from utils.rank_sorting_class import Ranker
 from utils.riot_client import (
@@ -390,12 +390,23 @@ class FetchFromRiot(commands.Cog):
         except Exception as e:
             self.bot.logging.error(f"Failed to read history for {user}: {e!r}")
             return
+        shrink_detected = False
         try:
             if last_values[0] == (
                 user_stats_dict["wins"],
                 user_stats_dict["losses"],
             ):
                 return
+            prev = last_values[0]
+            new_games = user_stats_dict["wins"] + user_stats_dict["losses"]
+            if None not in prev and new_games < sum(prev):
+                # Games totals never shrink within a split — this account
+                # just crossed a ladder reset.
+                self.bot.logging.info(
+                    f"Games total shrank for {user} ({sum(prev)} -> {new_games}) — "
+                    "possible season reset, re-syncing seasons table"
+                )
+                shrink_detected = True
         except Exception:
             self.bot.logging.info(f"No prior history for {user} — first snapshot")
 
@@ -406,6 +417,10 @@ class FetchFromRiot(commands.Cog):
             f"{user_stats_dict['wins']}W/{user_stats_dict['losses']}L"
         )
         await leaderboard.insert_history_snapshot(user_stats_dict, SOLO_QUEUE)
+        if shrink_detected:
+            # After the insert so the shrunken snapshot itself is part of
+            # the derivation (utils/seasons.py needs it in league_history).
+            await seasons.sync_seasons()
         return
 
 

--- a/Bot/cogs/ranked_graphing.py
+++ b/Bot/cogs/ranked_graphing.py
@@ -7,20 +7,21 @@ import matplotlib.pyplot as plt
 from discord import app_commands
 from discord.ext import commands
 from main import MyDiscordBot
-from utils import db
+from utils import db, seasons
 from utils.add_a_cheg import ChegClass
 from utils.autocomplete import DiscordAttachedLeagueNames
 from utils.rank_sorting_class import Ranker
 
-# Start of the current ranked tracking window. Update manually when a new
-# year/season starts. Currently set to the 2026 ranked year opener
-# ('For Demacia', Season 1) — 2026-01-08 noon local server time per
-# Riot's annual cycle announcement. Includes all of 2026's ranked games.
-CURRENT_SPLIT_START = "2026-01-08 12:00:00"
-# TIMESTAMPTZ comparisons want a tz-aware datetime, not a string.
-_SPLIT_START_DT = dt.datetime.strptime(CURRENT_SPLIT_START, "%Y-%m-%d %H:%M:%S").replace(
-    tzinfo=dt.UTC
-)
+# FALLBACK start of the ranked tracking window, used only while the
+# seasons table is empty. Graphs normally read the latest auto-detected
+# ladder reset from utils/seasons.py — no more manual updates on a new
+# season. (Value: the 2026 ranked year opener, 2026-01-08 noon.)
+FALLBACK_SPLIT_START = dt.datetime(2026, 1, 8, 12, 0, 0, tzinfo=dt.UTC)
+
+
+async def _split_start() -> dt.datetime:
+    """Start of the current ladder: latest detected reset, or the fallback."""
+    return await seasons.current_season_start() or FALLBACK_SPLIT_START
 
 
 class LeagueGraphs(commands.Cog):
@@ -62,14 +63,15 @@ class LeagueGraphs(commands.Cog):
         # Match on either via a UNION subquery so legacy-tracked players
         # (e.g. DARWIN DARWIN N) actually see their post-migration games.
         # Solo queue only — Ranked 5s snapshots share league_history.
+        split_start = await _split_start()
         points = await db.fetchall(
-            "SELECT * FROM league_history WHERE timestamp > %s "
+            "SELECT * FROM league_history WHERE timestamp >= %s "
             "AND queue = 'RANKED_SOLO_5x5' AND puuid IN ("
             "    SELECT leagueId FROM league_players WHERE league_username = %s"
             "    UNION"
             "    SELECT puuid FROM league_players WHERE league_username = %s"
             ") ORDER BY timestamp ASC",
-            (_SPLIT_START_DT, league_name, league_name),
+            (split_start, league_name, league_name),
         )
         x_to_plot = []
         y_to_plot = []
@@ -81,7 +83,7 @@ class LeagueGraphs(commands.Cog):
         if not y_to_plot:
             await ctx.followup.send(
                 f"No ranked games for {league_name} since the current split "
-                f"started ({CURRENT_SPLIT_START})."
+                f"started ({split_start:%Y-%m-%d})."
             )
             return
 
@@ -142,14 +144,15 @@ class LeagueGraphs(commands.Cog):
         # plt._backend_mod.new_figure_manager_given_figure(1, fig)
         # See generate_singular: match both legacy leagueId and modern
         # puuid via UNION so legacy-tracked players surface correctly.
+        split_start = await _split_start()
         points = await db.fetchall(
-            "SELECT * FROM league_history WHERE timestamp > %s "
+            "SELECT * FROM league_history WHERE timestamp >= %s "
             "AND queue = 'RANKED_SOLO_5x5' AND puuid IN ("
             "    SELECT leagueId FROM league_players WHERE league_username = %s"
             "    UNION"
             "    SELECT puuid FROM league_players WHERE league_username = %s"
             ") ORDER BY timestamp ASC",
-            (_SPLIT_START_DT, league_name, league_name),
+            (split_start, league_name, league_name),
         )
         score_dict = {}
         for point in points:
@@ -168,7 +171,7 @@ class LeagueGraphs(commands.Cog):
         if not score_dict:
             await ctx.followup.send(
                 f"No ranked games for {league_name} since the current split "
-                f"started ({CURRENT_SPLIT_START})."
+                f"started ({split_start:%Y-%m-%d})."
             )
             return
 

--- a/Bot/cogs/weekly_awards.py
+++ b/Bot/cogs/weekly_awards.py
@@ -135,8 +135,14 @@ class WeeklyAwards(commands.Cog):
             # Nothing recorded — the next tick retries the whole ceremony.
             return
 
-        results = await awards.compute_all_awards(week_start, week_end)
-        blocks = awards.build_ceremony_blocks(week_start.date(), results)
+        results, season_reset = await awards.compute_all_awards(week_start, week_end)
+        if season_reset:
+            self.bot.logging.info(
+                "Season reset detected in awarded week — cross-reset LP deltas excluded"
+            )
+        blocks = awards.build_ceremony_blocks(
+            week_start.date(), results, season_reset=season_reset
+        )
 
         self.bot.logging.info(
             f"Posting weekly awards for week of {week_start.date()} "
@@ -269,12 +275,14 @@ class WeeklyAwards(commands.Cog):
         await ctx.response.defer(ephemeral=True)
         now_london = dt.datetime.now(awards.LONDON)
         week_start, _week_end = awards.week_bounds(now_london)
-        results = await awards.compute_all_awards(week_start, now_london)
+        results, season_reset = await awards.compute_all_awards(week_start, now_london)
         header = (
             f"\U0001f3c6 **Weekly Awards — preview** — week of "
             f"<t:{awards.week_epoch(week_start.date())}:d> so far (nothing recorded)"
         )
-        blocks = awards.build_ceremony_blocks(week_start.date(), results, header=header)
+        blocks = awards.build_ceremony_blocks(
+            week_start.date(), results, header=header, season_reset=season_reset
+        )
         for message_text in leaderboard.chunk_blocks(blocks):
             await ctx.followup.send(
                 message_text,

--- a/Bot/cogs/weekly_awards.py
+++ b/Bot/cogs/weekly_awards.py
@@ -140,9 +140,7 @@ class WeeklyAwards(commands.Cog):
             self.bot.logging.info(
                 "Season reset detected in awarded week — cross-reset LP deltas excluded"
             )
-        blocks = awards.build_ceremony_blocks(
-            week_start.date(), results, season_reset=season_reset
-        )
+        blocks = awards.build_ceremony_blocks(week_start.date(), results, season_reset=season_reset)
 
         self.bot.logging.info(
             f"Posting weekly awards for week of {week_start.date()} "

--- a/Bot/db/setup.postgres.sql
+++ b/Bot/db/setup.postgres.sql
@@ -143,3 +143,15 @@ create table if not exists weekly_awards (
     created_at TIMESTAMPTZ not null default now(),
     unique (week_start, award, discord_user_id)
 );
+
+-- Auto-detected season/split boundaries (utils/seasons.py): one row per
+-- ladder reset, derived from league_history games totals shrinking.
+-- started_at is the first post-reset snapshot observed — Riot's actual
+-- reset moment is a little earlier, bounded by how fast the first
+-- tracked player re-placed. Consumers (e.g. the ranked graphs) read
+-- MAX(started_at) as "the current ladder began here".
+create table if not exists seasons (
+    id BIGINT generated always as identity primary key,
+    started_at TIMESTAMPTZ not null unique,
+    detected_at TIMESTAMPTZ not null default now()
+);

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -6,7 +6,7 @@ import sys
 
 import discord
 from discord.ext.commands import Bot
-from utils import config, db
+from utils import config, db, seasons
 
 # .env loading + every env read lives in utils/config.py.
 
@@ -101,6 +101,12 @@ async def main(my_token: str) -> None:
     # schema is already current.
     await db.apply_schema("./db/setup.postgres.sql")
     logging.getLogger().info("Database schema applied")
+
+    # Backfill/refresh auto-detected season boundaries. Idempotent; also
+    # re-triggered live when the rank loop sees a games-total shrink.
+    new_boundaries = await seasons.sync_seasons()
+    if new_boundaries:
+        logging.getLogger().info(f"Seasons table: recorded {new_boundaries} new boundary(ies)")
 
     server_id = config.guild_id()
 

--- a/Bot/utils/awards.py
+++ b/Bot/utils/awards.py
@@ -38,6 +38,18 @@ INT = "int_of_the_week"
 
 AWARD_ORDER = (LP_LOSS, LP_CHAD, PUSSY, DUO_LEECH, INT)
 
+# Season-reset detection: within a split a player's wins+losses total only
+# ever grows, so an account whose games total SHRINKS across the week
+# straddled a split reset. One shrinking account could be a region
+# transfer or API quirk; this many agreeing means the ladder itself reset
+# (validated against 2024-2026 history: real resets cluster at 4-8
+# accounts, noise never exceeds 1).
+RESET_MIN_ACCOUNTS = 2
+
+# Replaces the LP awards' skip lines on a reset week — the normal lines
+# ("Disgustingly competent") would read as a stats claim that's wrong.
+RESET_LP_SKIP_LINE = "Season reset — the ladder ate everyone's LP. Fresh climb, fresh pain."
+
 
 @dataclass(frozen=True)
 class AwardMeta:
@@ -220,25 +232,60 @@ def net_lp_deltas(
     baseline_rows: list[tuple],
     first_in_week_rows: list[tuple],
     last_in_week_rows: list[tuple],
-) -> dict[int, dict]:
+) -> tuple[dict[int, dict], int]:
     """Net weekly LP delta per Discord user, summed across their accounts.
 
     All three row lists share the shape ``(puuid, discord_user_id,
-    display_name, league_username, tier, division, lp)`` with one row per
-    account (see fetch_lp_snapshot_rows). Per account: end = last snapshot
-    inside the week; start = latest snapshot at-or-before week start,
-    falling back to the earliest snapshot inside the week. Accounts with
-    no in-week snapshot contribute nothing — league_history only writes
-    on LP change, so no row means no movement. Accounts whose tier string
-    absolute_lp doesn't know are skipped rather than poisoning the sum.
+    display_name, league_username, tier, division, lp, wins, losses)``
+    with one row per account (see fetch_lp_snapshot_rows). Per account:
+    end = last snapshot inside the week; start = latest snapshot
+    at-or-before week start, falling back to the earliest snapshot inside
+    the week. Accounts with no in-week snapshot contribute nothing —
+    league_history only writes on LP change, so no row means no movement.
+    Accounts whose tier string absolute_lp doesn't know are skipped
+    rather than poisoning the sum.
+
+    Season-reset handling — a player's wins+losses total only ever grows
+    within a split, so a shrink marks a reset crossing:
+
+    - baseline -> first-in-week shrank: the account crossed a reset
+      BEFORE the week (late returner). Its baseline is old-ladder LP, so
+      the delta rebases to the first in-week snapshot — the week counts
+      new-ladder movement only. Doesn't count toward reset detection.
+      A baseline with UNKNOWN games (legacy row, NULL wins/losses) also
+      rebases: it can't be trusted across a possible reset, and one
+      slipping through once mis-measured a Silver placement climb as
+      +723 LP against a years-old snapshot.
+    - start -> last-in-week shrank: the reset happened INSIDE the week.
+      No comparable pair of snapshots exists (a placement demotion reads
+      as -700 LP), so the account is excluded and counted in the second
+      return value. The caller compares that count to RESET_MIN_ACCOUNTS
+      to decide the whole week was a reset week.
     """
     baselines = {row[0]: row for row in baseline_rows}
     firsts = {row[0]: row for row in first_in_week_rows}
     per_user: dict[int, dict] = {}
-    for puuid, user_id, display_name, league_username, tier, division, lp in last_in_week_rows:
+    reset_accounts = 0
+
+    def games(row: tuple) -> int | None:
+        if row[7] is None and row[8] is None:
+            return None  # legacy snapshot predating the wins/losses columns
+        return (row[7] or 0) + (row[8] or 0)
+
+    for row in last_in_week_rows:
+        puuid, user_id, display_name, league_username, tier, division, lp, wins, losses = row
         start = baselines.get(puuid) or firsts.get(puuid)
         if start is None:
             continue  # unreachable: a last-in-week row implies a first-in-week row
+        first = firsts.get(puuid)
+        if first is not None and start is not first:
+            start_games, first_games = games(start), games(first)
+            if start_games is None or (first_games is not None and first_games < start_games):
+                start = first  # crossed a reset (or untrustable baseline) — rebase
+        start_games, end_games = games(start), games(row)
+        if start_games is not None and end_games is not None and end_games < start_games:
+            reset_accounts += 1
+            continue
         try:
             delta = absolute_lp(tier, division, lp) - absolute_lp(start[4], start[5], start[6])
         except ValueError:
@@ -248,7 +295,7 @@ def net_lp_deltas(
         )
         entry["delta"] += delta
         entry["per_account"][league_username] = delta
-    return per_user
+    return per_user, reset_accounts
 
 
 def pick_lp_extreme(per_user: dict[int, dict], *, gain: bool) -> list[Winner]:
@@ -490,6 +537,8 @@ def build_ceremony_blocks(
     week_start: dt.date,
     results: dict[str, list[Winner]],
     header: str | None = None,
+    *,
+    season_reset: bool = False,
 ) -> list[str]:
     """Ceremony post as blocks for leaderboard.chunk_blocks.
 
@@ -497,6 +546,9 @@ def build_ceremony_blocks(
     number, one roast. Joint winners share a block, one detail line each.
     Every block ends with a newline so chunked messages get a blank line
     between awards.
+
+    ``season_reset``: swaps the LP awards' skip lines for the reset line
+    — their normal skip lines claim nobody moved, which would be false.
     """
     if header is None:
         header = f"\U0001f3c6 **Weekly Awards** — week of <t:{week_epoch(week_start)}:d>"
@@ -505,7 +557,12 @@ def build_ceremony_blocks(
         meta = AWARDS[award]
         winners = results.get(award) or []
         if not winners:
-            blocks.append(f"{meta.emoji} **{meta.title}** — no winner\n{meta.skip_line}\n")
+            skip = (
+                RESET_LP_SKIP_LINE
+                if season_reset and award in (LP_LOSS, LP_CHAD)
+                else meta.skip_line
+            )
+            blocks.append(f"{meta.emoji} **{meta.title}** — no winner\n{skip}\n")
             continue
         mentions = " & ".join(f"<@{winner.user_id}>" for winner in winners)
         if len(winners) == 1:
@@ -629,7 +686,7 @@ def _snapshot_query(where: str, order: str) -> str:
         + """
         SELECT DISTINCT ON (lh.puuid)
                lh.puuid, t.discord_user_id, t.display_name, t.league_username,
-               lh.tier, lh.division, lh.lp
+               lh.tier, lh.division, lh.lp, lh.wins, lh.losses
         FROM league_history lh
             JOIN tracked t ON t.puuid = lh.puuid
         WHERE lh.queue = %(queue)s
@@ -789,13 +846,23 @@ async def fetch_int_rows(week_start: dt.datetime, week_end: dt.datetime) -> list
 
 async def compute_all_awards(
     week_start: dt.datetime, week_end: dt.datetime
-) -> dict[str, list[Winner]]:
-    """All five awards for [week_start, week_end) — empty list = skipped."""
+) -> tuple[dict[str, list[Winner]], bool]:
+    """All five awards for [week_start, week_end) — empty list = skipped.
+
+    Second return: True when the reset happened inside the window
+    (RESET_MIN_ACCOUNTS+ accounts' games totals shrank in-week). On a
+    reset week the LP awards are skipped outright — some players' deltas
+    would be old-ladder tail movement and others' new-ladder placement
+    climbs, which isn't a comparable field — and the ceremony swaps in
+    the reset skip line. The match-derived awards (volume, duo, int) are
+    unaffected by a reset: games played are games played.
+    """
     baseline, first, last = await fetch_lp_snapshot_rows(week_start, week_end)
-    deltas = net_lp_deltas(baseline, first, last)
-    return {
-        LP_LOSS: pick_lp_extreme(deltas, gain=False),
-        LP_CHAD: pick_lp_extreme(deltas, gain=True),
+    deltas, reset_accounts = net_lp_deltas(baseline, first, last)
+    season_reset = reset_accounts >= RESET_MIN_ACCOUNTS
+    results = {
+        LP_LOSS: [] if season_reset else pick_lp_extreme(deltas, gain=False),
+        LP_CHAD: [] if season_reset else pick_lp_extreme(deltas, gain=True),
         PUSSY: pick_volume_collapse(await fetch_volume_rows(week_start, week_end)),
         DUO_LEECH: pick_duo_leech(
             await fetch_duo_rows(week_start, week_end),
@@ -803,3 +870,4 @@ async def compute_all_awards(
         ),
         INT: pick_int(await fetch_int_rows(week_start, week_end)),
     }
+    return results, season_reset

--- a/Bot/utils/seasons.py
+++ b/Bot/utils/seasons.py
@@ -1,0 +1,112 @@
+"""Auto-detected season/split boundaries, persisted in the seasons table.
+
+Within a split a player's league-entries wins+losses total only ever
+grows, so a tracked account whose games total shrinks between two
+consecutive league_history snapshots crossed a ladder reset. A single
+account can shrink for other reasons (region transfer, API quirk);
+awards.RESET_MIN_ACCOUNTS distinct accounts shrinking within one
+CLUSTER_WINDOW marks a real reset. Validated against 2023-2026 history:
+real resets (Jan/May/Sept 2024, Jan 2026) cluster at 4-8 accounts over
+up to four weeks as players trickle back into placements, noise never
+exceeded one account — and years where Riot left W/L intact across a
+split (2025) correctly produce no boundary, because nothing was wiped.
+
+The recorded started_at is the first post-reset snapshot observed —
+Riot's actual reset moment is a little earlier, bounded by how fast the
+first player re-placed. That's exact enough for "current ladder only"
+filters: between the real reset and the first re-placement no snapshots
+exist at all (players have no ranked entry until placements finish).
+
+sync_seasons() is idempotent and cheap. It runs at boot (backfilling
+every historical boundary on first deploy) and again whenever the solo
+board observes a games-total shrink on a live account
+(cogs/league_table_updater.update_table).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+from utils import db
+from utils.awards import RESET_MIN_ACCOUNTS
+
+log = logging.getLogger(__name__)
+
+# Shrink events this close together belong to the same reset — players
+# trickle back into placements over weeks (Sept 2024 spanned four).
+# Real split gaps are months apart, so clusters can't run together.
+CLUSTER_WINDOW = dt.timedelta(days=21)
+
+# A derived boundary this close to an existing seasons row is the same
+# reset re-derived (its cluster's first event can't move once seen, but
+# belt-and-braces against clock/ordering edge cases), not a new season.
+DEDUPE_WINDOW = dt.timedelta(days=30)
+
+
+async def _shrink_events() -> list[tuple]:
+    """(timestamp, puuid) of every consecutive-snapshot games shrink."""
+    return await db.fetchall(
+        """WITH ordered AS (
+            SELECT puuid, timestamp, wins + losses AS games,
+                   LAG(wins + losses) OVER (
+                       PARTITION BY puuid ORDER BY timestamp, id
+                   ) AS prev_games
+            FROM league_history
+            WHERE queue = 'RANKED_SOLO_5x5'
+              AND wins IS NOT NULL AND losses IS NOT NULL
+        )
+        SELECT timestamp, puuid FROM ordered
+        WHERE prev_games IS NOT NULL AND games < prev_games
+        ORDER BY timestamp"""
+    )
+
+
+def cluster_boundaries(events: list[tuple]) -> list[dt.datetime]:
+    """First-event timestamp of each cluster with enough distinct accounts.
+
+    Pure: consecutive events gapped <= CLUSTER_WINDOW share a cluster;
+    a cluster of at least RESET_MIN_ACCOUNTS distinct accounts is a real
+    reset and contributes its earliest timestamp as the boundary.
+    """
+    boundaries: list[dt.datetime] = []
+    cluster_start: dt.datetime | None = None
+    last_seen: dt.datetime | None = None
+    accounts: set[str] = set()
+
+    def flush() -> None:
+        if cluster_start is not None and len(accounts) >= RESET_MIN_ACCOUNTS:
+            boundaries.append(cluster_start)
+
+    for timestamp, puuid in events:
+        if last_seen is None or timestamp - last_seen > CLUSTER_WINDOW:
+            flush()
+            cluster_start = timestamp
+            accounts = set()
+        accounts.add(puuid)
+        last_seen = timestamp
+    flush()
+    return boundaries
+
+
+async def sync_seasons() -> int:
+    """Derive boundaries and insert any not yet recorded. Returns count."""
+    boundaries = cluster_boundaries(await _shrink_events())
+    existing = [row[0] for row in await db.fetchall("SELECT started_at FROM seasons")]
+    inserted = 0
+    for boundary in boundaries:
+        if any(abs(boundary - seen) <= DEDUPE_WINDOW for seen in existing):
+            continue
+        await db.execute(
+            "INSERT INTO seasons (started_at) VALUES (%s) ON CONFLICT DO NOTHING",
+            (boundary,),
+        )
+        inserted += 1
+        log.info(f"Season boundary recorded: ladder reset detected around {boundary:%Y-%m-%d}")
+    return inserted
+
+
+async def current_season_start() -> dt.datetime | None:
+    """started_at of the latest detected season, or None before any."""
+    row = await db.fetchone("SELECT MAX(started_at) FROM seasons")
+    return row[0] if row is not None else None


### PR DESCRIPTION
Stacked on #71 (retargets to main automatically when that merges).

Ends the manual-season era: no more hand-editing `CURRENT_SPLIT_START` when Riot resets the ladder, and no more LP awards crowning placement carnage.

## The signal

Within a split, a player's `wins + losses` from Riot's league entries only ever **grows**. An account whose games total shrinks crossed a ladder reset. Validated against the full 2023–2026 `league_history`: real resets cluster at 4+ distinct accounts (players trickle back into placements over up to 4 weeks); noise (transfers/quirks) never exceeds one account. Threshold: **2+ accounts**.

## What's in here

**1. Weekly awards guard** (`utils/awards.py`, `cogs/weekly_awards.py`)
- 2+ accounts shrinking in-week = reset week → both LP awards skip with a dedicated line (*“Season reset — the ladder ate everyone's LP. Fresh climb, fresh pain.”*). Volume/duo/int awards run unchanged.
- Late returners (baseline predates a reset) and untrustable legacy baselines (NULL wins/losses) rebase to their first in-week snapshot. Found live: a legacy baseline mis-measured a Silver placement climb as **+723 LP**; rebased it reads +106.

**2. Persistent seasons registry** (`db/setup.postgres.sql`, `utils/seasons.py`)
- New `seasons` table, one row per detected ladder reset. Auto-populated: at boot (backfills all history on first deploy) and live from the rank loop the moment an account's games total shrinks.
- Validated read-only against prod — finds exactly the four real resets, two of them within hours of Riot's actual reset time:

| Detected | Riot's actual reset |
|---|---|
| 2024-01-14 | ~Jan 10 2024 (S14 Split 1) |
| 2024-05-16 | May 15 2024 (Split 2) |
| 2024-09-25 | Sept 25 2024 (Split 3) |
| 2026-01-08 19:02 | Jan 8 2026 (manual constant said 12:00) |

- 2025's splits (no W/L wipe in entries) correctly produce no boundary — the detector keys on actual ladder wipes, not Riot's naming.

**3. Graphs use it** (`cogs/ranked_graphing.py`)
- `/graph_user_granular` and `/graph_user_average` read `seasons.current_season_start()` instead of the hardcoded constant (old value kept as fallback while the table is empty). Queries switch to `>=` so the first post-reset snapshot isn't dropped.

## Verification
- Jan 2026 reset week: flagged, LP awards skip, other awards intact; adjacent weeks sane; normal weeks byte-identical (read-only runs against prod Postgres).
- Boundary derivation validated read-only against prod (table above).

## Deploy note
Schema (`seasons` table) + `main.py` boot hook need a container restart after merge — auto_reload covers the cog/utils changes only.