### PR TITLE
fix(awards): reset week can't dodge detection via the rebase path

### DIFF
--- a/Bot/utils/awards.py
+++ b/Bot/utils/awards.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from zoneinfo import ZoneInfo
 
-from utils import db
+from utils import db, seasons
 from utils.riot_client import RANKED_SOLO_QUEUE_ID
 
 LONDON = ZoneInfo("Europe/London")
@@ -37,14 +37,6 @@ DUO_LEECH = "duo_leech"
 INT = "int_of_the_week"
 
 AWARD_ORDER = (LP_LOSS, LP_CHAD, PUSSY, DUO_LEECH, INT)
-
-# Season-reset detection: within a split a player's wins+losses total only
-# ever grows, so an account whose games total SHRINKS across the week
-# straddled a split reset. One shrinking account could be a region
-# transfer or API quirk; this many agreeing means the ladder itself reset
-# (validated against 2024-2026 history: real resets cluster at 4-8
-# accounts, noise never exceeds 1).
-RESET_MIN_ACCOUNTS = 2
 
 # Replaces the LP awards' skip lines on a reset week — the normal lines
 # ("Disgustingly competent") would read as a stats claim that's wrong.
@@ -259,8 +251,9 @@ def net_lp_deltas(
     - start -> last-in-week shrank: the reset happened INSIDE the week.
       No comparable pair of snapshots exists (a placement demotion reads
       as -700 LP), so the account is excluded and counted in the second
-      return value. The caller compares that count to RESET_MIN_ACCOUNTS
-      to decide the whole week was a reset week.
+      return value. The caller compares that count to
+      seasons.RESET_MIN_ACCOUNTS to decide the whole week was a reset
+      week.
     """
     baselines = {row[0]: row for row in baseline_rows}
     firsts = {row[0]: row for row in first_in_week_rows}
@@ -849,17 +842,25 @@ async def compute_all_awards(
 ) -> tuple[dict[str, list[Winner]], bool]:
     """All five awards for [week_start, week_end) — empty list = skipped.
 
-    Second return: True when the reset happened inside the window
-    (RESET_MIN_ACCOUNTS+ accounts' games totals shrank in-week). On a
-    reset week the LP awards are skipped outright — some players' deltas
-    would be old-ladder tail movement and others' new-ladder placement
-    climbs, which isn't a comparable field — and the ceremony swaps in
-    the reset skip line. The match-derived awards (volume, duo, int) are
-    unaffected by a reset: games played are games played.
+    Second return: True when the reset happened inside the window, from
+    either of two signals — the in-window shrink count reaching
+    seasons.RESET_MIN_ACCOUNTS, or a recorded seasons-table boundary
+    falling inside the window. Both are needed: a reset early in the
+    week leaves most accounts' first in-week snapshot already
+    post-reset, which the late-returner rebase absorbs (shrink count
+    stays low), but the boundary row written live by the rank loop still
+    lands inside the week. On a reset week the LP awards are skipped
+    outright — some players' deltas would be old-ladder tail movement
+    and others' new-ladder placement climbs, which isn't a comparable
+    field — and the ceremony swaps in the reset skip line. The
+    match-derived awards (volume, duo, int) are unaffected by a reset:
+    games played are games played.
     """
     baseline, first, last = await fetch_lp_snapshot_rows(week_start, week_end)
     deltas, reset_accounts = net_lp_deltas(baseline, first, last)
-    season_reset = reset_accounts >= RESET_MIN_ACCOUNTS
+    season_reset = reset_accounts >= seasons.RESET_MIN_ACCOUNTS or await seasons.reset_within(
+        week_start, week_end
+    )
     results = {
         LP_LOSS: [] if season_reset else pick_lp_extreme(deltas, gain=False),
         LP_CHAD: [] if season_reset else pick_lp_extreme(deltas, gain=True),

--- a/Bot/utils/seasons.py
+++ b/Bot/utils/seasons.py
@@ -4,7 +4,7 @@ Within a split a player's league-entries wins+losses total only ever
 grows, so a tracked account whose games total shrinks between two
 consecutive league_history snapshots crossed a ladder reset. A single
 account can shrink for other reasons (region transfer, API quirk);
-awards.RESET_MIN_ACCOUNTS distinct accounts shrinking within one
+RESET_MIN_ACCOUNTS distinct accounts shrinking within one
 CLUSTER_WINDOW marks a real reset. Validated against 2023-2026 history:
 real resets (Jan/May/Sept 2024, Jan 2026) cluster at 4-8 accounts over
 up to four weeks as players trickle back into placements, noise never
@@ -29,9 +29,16 @@ import datetime as dt
 import logging
 
 from utils import db
-from utils.awards import RESET_MIN_ACCOUNTS
 
 log = logging.getLogger(__name__)
+
+# Distinct shrinking accounts required before shrink events count as a
+# real ladder reset. One account can shrink for personal reasons (region
+# transfer, API quirk); two agreeing is a split reset. Validated against
+# 2024-2026 history: real resets cluster at 4-8 accounts, noise never
+# exceeds one. utils/awards.py shares this threshold for its own
+# in-window shrink count.
+RESET_MIN_ACCOUNTS = 2
 
 # Shrink events this close together belong to the same reset — players
 # trickle back into placements over weeks (Sept 2024 spanned four).
@@ -110,3 +117,20 @@ async def current_season_start() -> dt.datetime | None:
     """started_at of the latest detected season, or None before any."""
     row = await db.fetchone("SELECT MAX(started_at) FROM seasons")
     return row[0] if row is not None else None
+
+
+async def reset_within(start: dt.datetime, end: dt.datetime) -> bool:
+    """True when a recorded season boundary falls inside [start, end).
+
+    The weekly awards check this alongside their own in-window shrink
+    count. A reset early in the awarded week leaves most accounts' first
+    in-week snapshot already post-reset — the LP delta rebase absorbs
+    those shrinks, so the shrink count alone can miss the reset — but
+    the boundary row (written live by the rank loop the moment the first
+    player re-places) still lands inside the week.
+    """
+    row = await db.fetchone(
+        "SELECT 1 FROM seasons WHERE started_at >= %s AND started_at < %s LIMIT 1",
+        (start, end),
+    )
+    return row is not None


### PR DESCRIPTION
Follow-up hardening to #72, from post-merge review.

## The hole

`compute_all_awards` detected a reset week only from its own window arithmetic: accounts whose games total shrank **in-week**. But a reset landing early in the week (or on a quiet Monday) leaves most accounts' first in-week snapshot already post-reset — the late-returner rebase absorbs those shrinks, the count stays under threshold, and the LP awards post placement-climb garbage. Jan 2026 only validated cleanly because that reset hit on a Thursday.

## The fix

The ceremony now also consults the `seasons` table: a recorded boundary inside the awarded week = reset week, regardless of weekday. The boundary row is written live by the rank loop the moment the first player re-places, so it's always there by ceremony time (Monday 06:00+). `RESET_MIN_ACCOUNTS` moves to `utils/seasons.py` and `awards` imports it — flipping the dependency so no import cycle.

## Verification (read-only against prod)

- **2024-09-23** (Sept split): now flags **True** via the boundary signal — its shrink events are legacy-keyed and invisible to the awards join, exactly the missed-detection class ✅
- Trickle weeks (09-30, 10-07): still False ✅
- Jan 2026 reset week: True; adjacent + control weeks: unchanged ✅

## Prod note
The `seasons` table is already live: I applied the (idempotent, canonical) DDL ahead of the restart and ran the backfill — 4 boundaries recorded (2024-01-14, 2024-05-16, 2024-09-25, 2026-01-08). This also defused a pre-restart crash risk: the merged `update_table` sync trigger would have hit a missing table on the first live shrink. A container restart is still needed for `main.py`'s boot hooks + the rest of #71.