### PR TITLE
feat(dashboard): web dashboard scaffold — Discord OAuth2 login, Postgres views, bot_config controls

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,20 @@
+# Discord OAuth2 application (Developer Portal -> your app -> OAuth2).
+# The bot's existing application works — just add a Redirect URI there.
+discord_client_id=
+discord_client_secret=
+# Must byte-match a Redirect URI registered in the portal, e.g.
+# http://192.168.0.X:8000/auth/callback (LAN) or
+# https://dash.logans22.com/auth/callback (behind the proxy).
+oauth_redirect_uri=
+
+# Signs the session cookie. Generate once: openssl rand -hex 32
+session_secret=
+
+# Postgres — use the dashboard's own role (see README), NOT the bot's.
+DATABASE_URL=postgresql://chomage_dash:CHANGE_ME@192.168.0.Y:5432/chomage
+
+# Only members of this guild can log in.
+guild_id=667751882260742164
+
+# Comma-separated Discord user ids allowed to change bot_config.
+admin_user_ids=

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /dashboard
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,67 @@
+# Chomage dashboard
+
+Web dashboard for the Chomage bot: read views over the bot's Postgres
+(seasons, weekly awards, tracked players, bot config) plus runtime
+controls. Login is **Discord OAuth2 only**, restricted to members of the
+Discord server; config writes are further restricted to an admin
+allowlist.
+
+Runs in its own container (planned: a fresh LXC on the Proxmox host),
+talking to Postgres in CT 105. It never touches the bot process — the
+control surface is the `bot_config` table, which the bot already polls
+at runtime.
+
+## One-time setup
+
+### 1. Discord OAuth2 credentials
+
+1. https://discord.com/developers/applications → select the existing bot
+   application (or create one).
+2. **OAuth2** tab → **Redirects** → add your callback URL, e.g.
+   `http://192.168.0.X:8000/auth/callback`. It must byte-match
+   `oauth_redirect_uri` in `.env` (scheme, host, port, path).
+3. Copy the **Client ID** and **Client Secret** into `.env`.
+
+No bot token is needed — the app checks guild membership with the
+`guilds` OAuth scope of the logged-in user.
+
+### 2. Database role
+
+Give the dashboard its own role: read everything, write only bot_config.
+
+```sql
+CREATE ROLE chomage_dash LOGIN PASSWORD '...';
+GRANT CONNECT ON DATABASE chomage TO chomage_dash;
+GRANT USAGE ON SCHEMA public TO chomage_dash;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO chomage_dash;
+ALTER DEFAULT PRIVILEGES FOR ROLE chomage IN SCHEMA public
+    GRANT SELECT ON TABLES TO chomage_dash;
+GRANT INSERT, UPDATE ON bot_config TO chomage_dash;
+```
+
+### 3. Configure and run
+
+```sh
+cp .env.example .env   # fill in everything
+docker compose up -d --build
+```
+
+Visit `http://<host>:8000`, log in with Discord.
+
+## How the login works
+
+Authorization-code flow: `/login` redirects to Discord with our client
+id + a signed `state`; the user approves `identify guilds`; Discord
+redirects back to `/auth/callback` with a one-time code; the server
+exchanges code + client secret for an access token (secret stays
+server-side), asks Discord who the user is and which guilds they're in,
+and only guild members get a signed session cookie (7 days). No
+passwords, and the Discord access token is discarded after those two
+lookups.
+
+## Controls
+
+`POST /config` (admins only) upserts a `bot_config` key. The bot polls
+this table, so changes take effect without touching the bot — e.g.
+`ranked5s_channel_id`. New runtime switches should follow the same
+pattern: add a bot_config key the bot reads, control it from here.

--- a/dashboard/app/auth.py
+++ b/dashboard/app/auth.py
@@ -1,0 +1,123 @@
+"""Discord OAuth2 login — the dashboard's only authentication.
+
+Flow (authorization code grant):
+  1. /login redirects to Discord's authorize page with our client_id,
+     redirect_uri, scopes (identify + guilds) and a random signed state.
+  2. The user approves; Discord redirects back to /auth/callback with a
+     one-time code.
+  3. We exchange code + client_secret for an access token (server-side —
+     the secret never reaches the browser).
+  4. With the token we ask Discord who the user is (/users/@me) and what
+     guilds they're in (/users/@me/guilds). Members of guild_id get a
+     session; everyone else is rejected.
+  5. The session is a signed cookie (itsdangerous) holding id + name.
+     No passwords, no Discord tokens stored — the access token is used
+     for those two lookups and discarded.
+
+Admin writes are gated separately by admin_user_ids (see config.py).
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+from itsdangerous import BadSignature, URLSafeTimedSerializer
+
+from app import config
+
+DISCORD_API = "https://discord.com/api/v10"
+AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
+SCOPES = "identify guilds"
+
+SESSION_COOKIE = "session"
+SESSION_MAX_AGE = 7 * 24 * 3600  # re-login weekly
+STATE_COOKIE = "oauth_state"
+
+
+@dataclass(frozen=True)
+class SessionUser:
+    user_id: int
+    name: str
+
+    @property
+    def is_admin(self) -> bool:
+        return self.user_id in config.admin_user_ids()
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    return URLSafeTimedSerializer(config.session_secret())
+
+
+# ------------------------------------------------------------ oauth flow
+
+
+def new_state() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def authorize_url(state: str) -> str:
+    query = urlencode(
+        {
+            "client_id": config.discord_client_id(),
+            "response_type": "code",
+            "redirect_uri": config.oauth_redirect_uri(),
+            "scope": SCOPES,
+            "state": state,
+            "prompt": "none",
+        }
+    )
+    return f"{AUTHORIZE_URL}?{query}"
+
+
+async def exchange_code(code: str) -> str | None:
+    """One-time code -> access token, or None on failure."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            f"{DISCORD_API}/oauth2/token",
+            data={
+                "client_id": config.discord_client_id(),
+                "client_secret": config.discord_client_secret(),
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": config.oauth_redirect_uri(),
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    if response.status_code != 200:
+        return None
+    return response.json().get("access_token")
+
+
+async def fetch_member_user(access_token: str) -> SessionUser | None:
+    """The logged-in user, or None if they're not in the guild."""
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+        me = await client.get(f"{DISCORD_API}/users/@me")
+        guilds = await client.get(f"{DISCORD_API}/users/@me/guilds")
+    if me.status_code != 200 or guilds.status_code != 200:
+        return None
+    if not any(int(g["id"]) == config.guild_id() for g in guilds.json()):
+        return None
+    payload = me.json()
+    name = payload.get("global_name") or payload["username"]
+    return SessionUser(user_id=int(payload["id"]), name=name)
+
+
+# -------------------------------------------------------------- sessions
+
+
+def session_cookie_value(user: SessionUser) -> str:
+    return _serializer().dumps({"id": user.user_id, "name": user.name})
+
+
+def user_from_cookie(value: str | None) -> SessionUser | None:
+    if not value:
+        return None
+    try:
+        payload = _serializer().loads(value, max_age=SESSION_MAX_AGE)
+    except BadSignature:
+        return None
+    return SessionUser(user_id=int(payload["id"]), name=payload["name"])

--- a/dashboard/app/config.py
+++ b/dashboard/app/config.py
@@ -1,0 +1,52 @@
+"""Env-driven configuration — every setting the dashboard needs.
+
+Mirrors the bot's utils/config.py philosophy: env reads live here, no
+hardcoded credentials, missing required values fail loudly at startup.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"required env var {name} is not set")
+    return value
+
+
+def database_url() -> str:
+    return _require("DATABASE_URL")
+
+
+def discord_client_id() -> str:
+    return _require("discord_client_id")
+
+
+def discord_client_secret() -> str:
+    return _require("discord_client_secret")
+
+
+def oauth_redirect_uri() -> str:
+    """Must byte-match a Redirect URI registered in the Discord portal."""
+    return _require("oauth_redirect_uri")
+
+
+def session_secret() -> str:
+    """Signs the session cookie. Generate once: openssl rand -hex 32."""
+    return _require("session_secret")
+
+
+def guild_id() -> int:
+    """Only members of this guild may log in."""
+    return int(_require("guild_id"))
+
+
+def admin_user_ids() -> set[int]:
+    """Discord user ids allowed to change settings (comma-separated).
+
+    Everyone in the guild can view; only admins can write.
+    """
+    raw = os.environ.get("admin_user_ids", "")
+    return {int(part) for part in raw.split(",") if part.strip()}

--- a/dashboard/app/db.py
+++ b/dashboard/app/db.py
@@ -1,0 +1,50 @@
+"""Async Postgres access — one pool, same shape as the bot's utils/db.
+
+The dashboard connects with its own role (see README: SELECT on
+everything, INSERT/UPDATE only on bot_config) so a bug here can't
+corrupt match history.
+"""
+
+from __future__ import annotations
+
+from psycopg_pool import AsyncConnectionPool
+
+from app import config
+
+_pool: AsyncConnectionPool | None = None
+
+
+async def get_pool() -> AsyncConnectionPool:
+    global _pool
+    if _pool is None:
+        pool = AsyncConnectionPool(config.database_url(), min_size=1, max_size=4, open=False)
+        await pool.open(wait=True, timeout=30.0)
+        _pool = pool
+    return _pool
+
+
+async def fetchall(sql: str, params: tuple = ()) -> list[tuple]:
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        cur = await conn.execute(sql, params)
+        return await cur.fetchall()
+
+
+async def fetchone(sql: str, params: tuple = ()) -> tuple | None:
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        cur = await conn.execute(sql, params)
+        return await cur.fetchone()
+
+
+async def execute(sql: str, params: tuple = ()) -> None:
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        await conn.execute(sql, params)
+
+
+async def close() -> None:
+    global _pool
+    if _pool is not None:
+        await _pool.close()
+        _pool = None

--- a/dashboard/app/main.py
+++ b/dashboard/app/main.py
@@ -1,0 +1,137 @@
+"""Chomage dashboard — FastAPI app.
+
+Read views over the bot's Postgres (seasons, weekly awards, tracked
+players, bot_config) plus a control primitive: editing bot_config keys,
+which the bot already polls at runtime (e.g. ranked5s_channel_id). Auth
+is Discord OAuth2 only — see app/auth.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from app import auth, db
+
+log = logging.getLogger("dashboard")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+app = FastAPI(title="Chomage dashboard")
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    await db.close()
+
+
+def current_user(request: Request) -> auth.SessionUser | None:
+    return auth.user_from_cookie(request.cookies.get(auth.SESSION_COOKIE))
+
+
+# ----------------------------------------------------------------- auth
+
+
+@app.get("/login")
+async def login() -> RedirectResponse:
+    state = auth.new_state()
+    response = RedirectResponse(auth.authorize_url(state))
+    # State round-trips via a short-lived cookie and must match on the
+    # callback — standard CSRF protection for the OAuth redirect.
+    response.set_cookie(auth.STATE_COOKIE, state, max_age=600, httponly=True)
+    return response
+
+
+@app.get("/auth/callback")
+async def auth_callback(request: Request, code: str = "", state: str = "") -> RedirectResponse:
+    if not code or not state or state != request.cookies.get(auth.STATE_COOKIE):
+        return RedirectResponse("/?error=state")
+    token = await auth.exchange_code(code)
+    user = await auth.fetch_member_user(token) if token else None
+    if user is None:
+        log.warning("OAuth login rejected (bad code exchange or not a guild member)")
+        return RedirectResponse("/?error=denied")
+    log.info(f"Login: {user.name} ({user.user_id}), admin={user.is_admin}")
+    response = RedirectResponse("/")
+    response.delete_cookie(auth.STATE_COOKIE)
+    response.set_cookie(
+        auth.SESSION_COOKIE,
+        auth.session_cookie_value(user),
+        max_age=auth.SESSION_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+@app.get("/logout")
+async def logout() -> RedirectResponse:
+    response = RedirectResponse("/")
+    response.delete_cookie(auth.SESSION_COOKIE)
+    return response
+
+
+# ----------------------------------------------------------------- pages
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    user = current_user(request)
+    if user is None:
+        return templates.TemplateResponse(
+            "login.html", {"request": request, "error": request.query_params.get("error")}
+        )
+
+    seasons = await db.fetchall(
+        "SELECT started_at, detected_at FROM seasons ORDER BY started_at DESC"
+    )
+    awards = await db.fetchall(
+        "SELECT week_start, award, display_name, value FROM weekly_awards "
+        "WHERE week_start = (SELECT MAX(week_start) FROM weekly_awards) ORDER BY id"
+    )
+    players = await db.fetchall(
+        "SELECT league_username, discord_user_id FROM league_players "
+        "WHERE puuid IS NOT NULL ORDER BY league_username"
+    )
+    bot_config = await db.fetchall("SELECT key, value, updated_at FROM bot_config ORDER BY key")
+    return templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "user": user,
+            "seasons": seasons,
+            "awards": awards,
+            "players": players,
+            "bot_config": bot_config,
+        },
+    )
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    await db.fetchone("SELECT 1")
+    return {"ok": True}
+
+
+# --------------------------------------------------------------- control
+
+
+@app.post("/config")
+async def set_config(request: Request, key: str = Form(...), value: str = Form(...)):
+    """Upsert a bot_config key — the bot polls this table at runtime."""
+    user = current_user(request)
+    if user is None:
+        return RedirectResponse("/", status_code=303)
+    if not user.is_admin:
+        return RedirectResponse("/?error=admin", status_code=303)
+    await db.execute(
+        "INSERT INTO bot_config (key, value, updated_at) VALUES (%s, %s, now()) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()",
+        (key.strip(), value.strip()),
+    )
+    log.info(f"bot_config[{key.strip()}] set by {user.name} ({user.user_id})")
+    return RedirectResponse("/", status_code=303)

--- a/dashboard/app/templates/base.html
+++ b/dashboard/app/templates/base.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chomage dashboard</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
+    table { border-collapse: collapse; width: 100%; margin: 0.5rem 0 1.5rem; }
+    th, td { text-align: left; padding: 0.35rem 0.6rem; border-bottom: 1px solid #8884; }
+    h2 { margin-top: 2rem; }
+    header { display: flex; justify-content: space-between; align-items: baseline; }
+    .error { color: #c0392b; }
+    input, button { padding: 0.3rem 0.5rem; }
+    form.inline { display: flex; gap: 0.5rem; }
+  </style>
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/dashboard/app/templates/home.html
+++ b/dashboard/app/templates/home.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block content %}
+<header>
+  <h1>Chomage dashboard</h1>
+  <p>{{ user.name }}{% if user.is_admin %} (admin){% endif %} — <a href="/logout">log out</a></p>
+</header>
+{% if request.query_params.get("error") == "admin" %}<p class="error">Admins only.</p>{% endif %}
+
+<h2>Seasons (auto-detected ladder resets)</h2>
+<table>
+  <tr><th>Season started</th><th>Detected</th></tr>
+  {% for started_at, detected_at in seasons %}
+  <tr><td>{{ started_at.strftime("%Y-%m-%d %H:%M") }}</td><td>{{ detected_at.strftime("%Y-%m-%d %H:%M") }}</td></tr>
+  {% endfor %}
+</table>
+
+<h2>Latest weekly awards</h2>
+<table>
+  <tr><th>Week</th><th>Award</th><th>Winner</th><th>Value</th></tr>
+  {% for week_start, award, name, value in awards %}
+  <tr><td>{{ week_start }}</td><td>{{ award }}</td><td>{{ name }}</td><td>{{ value }}</td></tr>
+  {% endfor %}
+</table>
+
+<h2>Tracked players ({{ players | length }})</h2>
+<table>
+  <tr><th>League account</th><th>Discord user id</th></tr>
+  {% for name, user_id in players %}
+  <tr><td>{{ name }}</td><td>{{ user_id }}</td></tr>
+  {% endfor %}
+</table>
+
+<h2>Bot config</h2>
+<table>
+  <tr><th>Key</th><th>Value</th><th>Updated</th></tr>
+  {% for key, value, updated_at in bot_config %}
+  <tr><td>{{ key }}</td><td>{{ value }}</td><td>{{ updated_at.strftime("%Y-%m-%d %H:%M") }}</td></tr>
+  {% endfor %}
+</table>
+{% if user.is_admin %}
+<form class="inline" method="post" action="/config">
+  <input name="key" placeholder="key" required>
+  <input name="value" placeholder="value" required>
+  <button type="submit">Set</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/dashboard/app/templates/login.html
+++ b/dashboard/app/templates/login.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Chomage dashboard</h1>
+{% if error == "denied" %}<p class="error">Login rejected — you need to be a member of the server.</p>{% endif %}
+{% if error == "state" %}<p class="error">Login flow expired — try again.</p>{% endif %}
+<p><a href="/login">Log in with Discord</a></p>
+{% endblock %}

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  dashboard:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    restart: unless-stopped

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.*
+uvicorn[standard]==0.30.*
+jinja2==3.1.*
+httpx==0.27.*
+itsdangerous==2.2.*
+psycopg[binary,pool]==3.2.*
+python-multipart==0.0.*


### PR DESCRIPTION
Scaffold for the control dashboard discussed today. Self-contained under `dashboard/` — nothing in `Bot/` changes.

## What's here
- **FastAPI app**: home page shows auto-detected seasons, the latest weekly awards, tracked players, and the `bot_config` table; `/healthz` for the proxy.
- **Discord OAuth2 as the only login** (authorization-code flow, `identify guilds` scopes): guild members get a signed 7-day session cookie; everyone else is rejected. No passwords, no stored tokens, client secret never leaves the server. CSRF-protected via signed `state`.
- **Controls**: `POST /config` (admin allowlist via `admin_user_ids` env) upserts `bot_config` keys — the bot already polls that table at runtime, so this is a zero-coupling control surface. New switches = new bot_config keys.
- **Packaging**: Dockerfile, compose, `.env.example`, README with Discord-portal steps and a least-privilege `chomage_dash` DB role (SELECT everywhere, INSERT/UPDATE on bot_config only).

## Still to come (separate steps)
- LXC container on the Proxmox host + proxy/WireGuard exposure decision
- OAuth client id/secret + redirect URI (owner creates in the developer portal)
- `chomage_dash` role creation on CT 105