### PR TITLE
feat(live): spectator-v5 live-game tracking for the dashboard

### DIFF
--- a/Bot/cogs/backfill.py
+++ b/Bot/cogs/backfill.py
@@ -38,6 +38,7 @@ from discord.ext import commands, tasks
 from psycopg.types.json import Jsonb
 from utils import db
 from utils.loop_restart import restart_loop_later
+from utils.queue_windows import is_ranked5s_tracking
 from utils.riot_client import (
     RANKED_5S_QUEUE_ID,
     RANKED_SOLO_QUEUE_ID,
@@ -232,10 +233,15 @@ class Backfill(commands.Cog):
             "SELECT puuid, league_username FROM league_players "
             "WHERE puuid IS NOT NULL AND puuid != ''"
         )
+        # The 5s queue only exists on weekend evenings — polling its match
+        # ids all week was ~8 wasted requests/2min of the shared budget.
+        # is_ranked5s_tracking covers the window plus a 2h tail, so games
+        # in flight at close still get picked up.
+        queues = (RANKED_SOLO_QUEUE_ID,) + ((RANKED_5S_QUEUE_ID,) if is_ranked5s_tracking() else ())
         for puuid, name in rows:
             try:
                 inserted = await self._backfill_player(
-                    puuid, count=STREAM_RECENT_COUNT, all_history=False, name=name
+                    puuid, count=STREAM_RECENT_COUNT, all_history=False, name=name, queues=queues
                 )
                 if inserted > 0:
                     self._stream_total_inserts += inserted
@@ -289,7 +295,12 @@ class Backfill(commands.Cog):
         self.bot.logging.info("Backfill: all players complete")
 
     async def _backfill_player(
-        self, puuid: str, count: int, all_history: bool = False, name: str | None = None
+        self,
+        puuid: str,
+        count: int,
+        all_history: bool = False,
+        name: str | None = None,
+        queues: tuple[int, ...] = (RANKED_SOLO_QUEUE_ID, RANKED_5S_QUEUE_ID),
     ) -> int:
         """Pull match IDs for the player and insert any not already stored.
 
@@ -300,16 +311,17 @@ class Backfill(commands.Cog):
 
         ``name`` is purely for log readability; falls back to a truncated
         puuid when not given (the stream loop always passes it).
+
+        ``queues`` defaults to both tracked queues — /backfill_all always
+        pulls full history for both; the stream passes solo-only outside
+        the weekend Ranked 5s window to spare the shared budget. Riot's
+        league API doesn't expose the 5s ladder, so queue-710 match rows
+        are also what the 5s board's fallback standings are built from.
         """
         inserted_total = 0
         label = name or f"{puuid[:8]}..."
 
-        # Track BOTH queues: ranked solo/duo and the weekend Ranked 5s
-        # (710). Riot's league API doesn't expose the 5s ladder yet, so
-        # these match rows are also what the 5s board's fallback standings
-        # are built from. 5s history is tiny (limited-test queue): steady
-        # state costs one extra id-page request per player per pass.
-        for queue in (RANKED_SOLO_QUEUE_ID, RANKED_5S_QUEUE_ID):
+        for queue in queues:
             start = 0
             page_num = 0
             while True:

--- a/Bot/cogs/heartbeat.py
+++ b/Bot/cogs/heartbeat.py
@@ -46,6 +46,9 @@ STICKY_PANEL_STALE_AFTER = dt.timedelta(minutes=15)
 # rationale: one missed tick is Gateway flap, three is a frozen loop.
 WEEKLY_AWARDS_STALE_AFTER = dt.timedelta(minutes=45)
 
+# 3× POLL_MINUTES from cogs.live_games (4 min spectator poll).
+LIVE_GAMES_STALE_AFTER = dt.timedelta(minutes=12)
+
 
 class Heartbeat(commands.Cog):
     """Restart frozen @tasks.loop tasks by reloading their parent cog."""
@@ -97,6 +100,13 @@ class Heartbeat(commands.Cog):
             extension="cogs.weekly_awards",
             attr="awards_tick_last_fired",
             stale_after=WEEKLY_AWARDS_STALE_AFTER,
+            now=now,
+        )
+        await self._check_one(
+            cog_name="LiveGames",
+            extension="cogs.live_games",
+            attr="poll_live_last_fired",
+            stale_after=LIVE_GAMES_STALE_AFTER,
             now=now,
         )
 

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -62,6 +62,10 @@ class FetchFromRiot(commands.Cog):
         # who finished game A and is already loading game B never leaves
         # the live set, but pair (puuid, A) vanishing still marks a finish.
         self._prev_live: set[tuple[str, int]] = set()
+        # Finishes announced directly by the live-games cog's fast path —
+        # authoritative and state-independent, so a sweep or reload wiping
+        # _prev_live between transition and fetch can't lose the signal.
+        self._pending_finished: set[str] = set()
         self._post_lock = asyncio.Lock()
 
     def cog_unload(self) -> None:
@@ -88,9 +92,26 @@ class FetchFromRiot(commands.Cog):
         the signals miss; every failure path fails open to fetching
         everyone.
         """
+        # Fast-path announcements are consumed on every branch — a sweep
+        # fetches everyone anyway, so they must not survive into later
+        # cycles and mask as still-pending.
+        pending = self._pending_finished
+        self._pending_finished = set()
         if time.monotonic() - self._entries_sweep_at >= ENTRIES_FULL_SWEEP_SECONDS:
             self._entries_sweep_at = time.monotonic()
-            self._prev_live = set()
+            # Keep the live-pair snapshot even on sweep cycles: wiping it
+            # made a game that ended before the next cycle invisible to
+            # the pair diff (stale ranks right after a sweep/reload).
+            try:
+                self._prev_live = {
+                    (row[0], row[1])
+                    for row in await db.fetchall(
+                        "SELECT DISTINCT puuid, game_id FROM live_games "
+                        "WHERE seen_at > now() - interval '6 minutes'"
+                    )
+                }
+            except Exception:
+                self._prev_live = set()
             return set()
         try:
             live = {
@@ -121,7 +142,37 @@ class FetchFromRiot(commands.Cog):
         except Exception as exc:
             self.bot.logging.warning(f"Entries gating unavailable, fetching all: {exc!r}")
             return set()
-        return tracked - just_finished - fresh_match
+        return tracked - just_finished - fresh_match - pending
+
+    def note_finished(self, puuids) -> None:
+        """Fast-path hook for the live-games cog: these players' games just
+        ended, so the next cycle must fresh-fetch them regardless of what
+        the pair diff can see."""
+        self._pending_finished |= set(puuids)
+
+    async def _live_board_marker(self) -> tuple[set[str], str]:
+        """(in-game puuids, marker suffix) for the board render.
+
+        The marker emoji comes from the bot_config key ``live_emoji`` so a
+        custom Discord emoji (``<:live:123...>``) can be set from the
+        dashboard without a deploy; defaults to 🔴. Empty set/marker when
+        live tracking isn't running — the board just renders plain.
+        """
+        try:
+            live = {
+                row[0]
+                for row in await db.fetchall(
+                    "SELECT DISTINCT puuid FROM live_games "
+                    "WHERE seen_at > now() - interval '12 minutes'"
+                )
+            }
+        except Exception:
+            return set(), ""
+        if not live:
+            return set(), ""
+        row = await db.fetchone("SELECT value FROM bot_config WHERE key = 'live_emoji'")
+        marker = row[0] if row and row[0] else "\U0001f534"
+        return live, f" {marker}"
 
     async def fetch_users_rank(self, users, stale_ok: set[str] = frozenset()):
         users_ranks = {}
@@ -351,6 +402,7 @@ class FetchFromRiot(commands.Cog):
 
         # apex_omits_games_word: this board's apex entries have always
         # read "Played: N with a ..." — see utils/leaderboard.py.
+        live_puuids, live_marker = await self._live_board_marker()
         (
             output_list,
             self.previous_positions,
@@ -361,6 +413,8 @@ class FetchFromRiot(commands.Cog):
             self.last_positions,
             self.get_last_five_games,
             apex_omits_games_word=True,
+            live_puuids=live_puuids,
+            live_marker=live_marker,
         )
         if output_list:
             # Key at the top of the board (William's call) — explains

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import time
 
 import discord
 from discord import app_commands
@@ -27,6 +28,12 @@ STREAK_THRESHOLD = 7
 # league_history.queue tag for this board's rows (also the column default).
 SOLO_QUEUE = "RANKED_SOLO_5x5"
 
+# Entries only change when a ranked game ENDS (plus rare apex decay), so
+# most cycles most players can be served from the stale entries cache.
+# A full fresh sweep this often catches decay and anything the change
+# signals miss.
+ENTRIES_FULL_SWEEP_SECONDS = 3600
+
 
 class FetchFromRiot(commands.Cog):
     def __init__(self, bot: MyDiscordBot):
@@ -48,6 +55,10 @@ class FetchFromRiot(commands.Cog):
         self.post_ranks_last_fired: dt.datetime | None = None
 
         self.ranked_dict: dict | None = None
+        # Entries-fetch gating state: 0.0 forces a full sweep on the first
+        # cycle after every (re)load, which also warms the stale cache.
+        self._entries_sweep_at = 0.0
+        self._prev_live: set[str] = set()
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
@@ -55,17 +66,66 @@ class FetchFromRiot(commands.Cog):
         # the old instance's loop running next to the new one's.
         self.post_ranks.cancel()
 
-    async def fetch_users_rank(self, users):
+    async def _entries_skip_set(self) -> set[str]:
+        """Players whose entries can't have changed since the last fetch.
+
+        LP only moves when a ranked game ends, so a player is skippable
+        (serve the stale entries cache) unless a game of theirs just
+        finished. "Just finished" is detected two ways, belt and braces:
+        they vanished from live_games since the previous cycle
+        (spectator saw the game end), or a fresh match_stats row landed
+        (the stream ingested the finished game). Players mid-game stay
+        skippable — their LP is frozen until the game ends. An hourly
+        full sweep catches apex decay and anything the signals miss, and
+        every failure path fails open to fetching everyone.
+        """
+        if time.monotonic() - self._entries_sweep_at >= ENTRIES_FULL_SWEEP_SECONDS:
+            self._entries_sweep_at = time.monotonic()
+            self._prev_live = set()
+            return set()
+        try:
+            live = {
+                row[0]
+                for row in await db.fetchall(
+                    "SELECT DISTINCT puuid FROM live_games "
+                    "WHERE seen_at > now() - interval '6 minutes'"
+                )
+            }
+            just_finished = self._prev_live - live
+            self._prev_live = live
+            fresh_match = {
+                row[0]
+                for row in await db.fetchall(
+                    "SELECT DISTINCT puuid FROM match_stats "
+                    "WHERE game_start > now() - interval '20 minutes'"
+                )
+            }
+            tracked = {
+                row[0]
+                for row in await db.fetchall(
+                    "SELECT DISTINCT puuid FROM league_players WHERE puuid IS NOT NULL"
+                )
+            }
+        except Exception as exc:
+            self.bot.logging.warning(f"Entries gating unavailable, fetching all: {exc!r}")
+            return set()
+        return tracked - just_finished - fresh_match
+
+    async def fetch_users_rank(self, users, stale_ok: set[str] = frozenset()):
         users_ranks = {}
         seen: set[str] = set()
         failed = 0
+        served_stale = 0
 
         # League-entries uses platform routing (euw1), not regional (europe).
         for puuid, name, user_id in users:
             if puuid in seen:
                 continue
             seen.add(puuid)
-            user_rank = await get_league_entries(puuid)
+            allow_stale = puuid in stale_ok
+            user_rank = await get_league_entries(puuid, allow_stale=allow_stale)
+            if allow_stale:
+                served_stale += 1
             if user_rank is None:
                 failed += 1
                 self.bot.logging.error(f"Failed to fetch rank for {name}")
@@ -94,8 +154,8 @@ class FetchFromRiot(commands.Cog):
         # line (~14 lines every 2 minutes). Failures still log per account
         # at ERROR above; loop liveness is the heartbeat cog's job.
         self.bot.logging.debug(
-            f"Rank fetch cycle: {len(seen) - failed}/{len(seen)} accounts fetched, "
-            f"{len(users_ranks)} on board"
+            f"Rank fetch cycle: {len(seen) - failed}/{len(seen)} accounts, "
+            f"{served_stale} served from stale cache, {len(users_ranks)} on board"
         )
         return users_ranks
 
@@ -110,8 +170,9 @@ class FetchFromRiot(commands.Cog):
         )
         # Fetch current ranks and store them in a dict with updated values.
         # Per-player API failures are handled inside fetch_users_rank
-        # (riot_client returns None rather than raising).
-        self.ranked_dict = await self.fetch_users_rank(rows)
+        # (riot_client returns None rather than raising). Players whose
+        # entries can't have moved are served from the stale cache.
+        self.ranked_dict = await self.fetch_users_rank(rows, await self._entries_skip_set())
         return
 
     async def get_last_five_games(self, puuid):

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -58,7 +58,10 @@ class FetchFromRiot(commands.Cog):
         # Entries-fetch gating state: 0.0 forces a full sweep on the first
         # cycle after every (re)load, which also warms the stale cache.
         self._entries_sweep_at = 0.0
-        self._prev_live: set[str] = set()
+        # (puuid, game_id) pairs — game-level, not just presence: a player
+        # who finished game A and is already loading game B never leaves
+        # the live set, but pair (puuid, A) vanishing still marks a finish.
+        self._prev_live: set[tuple[str, int]] = set()
         self._post_lock = asyncio.Lock()
 
     def cog_unload(self) -> None:
@@ -91,13 +94,15 @@ class FetchFromRiot(commands.Cog):
             return set()
         try:
             live = {
-                row[0]
+                (row[0], row[1])
                 for row in await db.fetchall(
-                    "SELECT DISTINCT puuid FROM live_games "
+                    "SELECT DISTINCT puuid, game_id FROM live_games "
                     "WHERE seen_at > now() - interval '6 minutes'"
                 )
             }
-            just_finished = self._prev_live - live
+            # Pair-level diff: (puuid, game_id) disappearing marks a finish
+            # even when the player is already in their NEXT game.
+            just_finished = {puuid for puuid, _ in self._prev_live - live}
             self._prev_live = live
             fresh_match = {
                 row[0]

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -59,6 +59,7 @@ class FetchFromRiot(commands.Cog):
         # cycle after every (re)load, which also warms the stale cache.
         self._entries_sweep_at = 0.0
         self._prev_live: set[str] = set()
+        self._post_lock = asyncio.Lock()
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
@@ -279,6 +280,13 @@ class FetchFromRiot(commands.Cog):
     @tasks.loop(seconds=120)
     async def post_ranks(self):
         await self.bot.wait_until_ready()
+        # Serialise the scheduled loop, /refresh_ranks and the live-games
+        # cog's end-of-game fast path — two concurrent runs would race
+        # wipe_and_post and double-wipe the board channel.
+        async with self._post_lock:
+            await self._post_ranks_once()
+
+    async def _post_ranks_once(self):
         await self.fetch_ranks_from_riot()
 
         # LP-diff bookkeeping stays gated on the fetched ranks moving:

--- a/Bot/cogs/league_table_updater.py
+++ b/Bot/cogs/league_table_updater.py
@@ -73,11 +73,16 @@ class FetchFromRiot(commands.Cog):
         (serve the stale entries cache) unless a game of theirs just
         finished. "Just finished" is detected two ways, belt and braces:
         they vanished from live_games since the previous cycle
-        (spectator saw the game end), or a fresh match_stats row landed
-        (the stream ingested the finished game). Players mid-game stay
-        skippable — their LP is frozen until the game ends. An hourly
-        full sweep catches apex decay and anything the signals miss, and
-        every failure path fails open to fetching everyone.
+        (spectator saw the game end), or a match_stats row whose game
+        ENDED recently exists (the stream ingested the finished game —
+        keyed on game_start + duration, NOT game_start: a 35-minute game
+        starts far outside any recency window by the time it's ingested,
+        so filtering on start time would miss almost every real game).
+        Players mid-game stay skippable — their LP is frozen until the
+        game ends. The hourly full sweep catches apex decay, queue-dodge
+        LP penalties (no game is ever created for those) and anything
+        the signals miss; every failure path fails open to fetching
+        everyone.
         """
         if time.monotonic() - self._entries_sweep_at >= ENTRIES_FULL_SWEEP_SECONDS:
             self._entries_sweep_at = time.monotonic()
@@ -97,7 +102,8 @@ class FetchFromRiot(commands.Cog):
                 row[0]
                 for row in await db.fetchall(
                     "SELECT DISTINCT puuid FROM match_stats "
-                    "WHERE game_start > now() - interval '20 minutes'"
+                    "WHERE game_start + make_interval(secs => COALESCE(duration_sec, 0)) "
+                    "      > now() - interval '30 minutes'"
                 )
             }
             tracked = {

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -143,22 +143,27 @@ class LiveGames(commands.Cog):
         known_games: dict[str, set[int]] = {}
         for puuid, game_id in rows:
             known_games.setdefault(puuid, set()).add(game_id)
-        ended = 0
+        ended: list[str] = []
         for puuid, game_ids in known_games.items():
             known, game = await get_active_game(puuid)
             if not known:
                 continue
             if game is None or not game.get("gameId"):
                 await db.execute("DELETE FROM live_games WHERE puuid = %s", (puuid,))
-                ended += 1
+                ended.append(puuid)
             elif game.get("gameId") not in game_ids:
                 # Already in the NEXT game — the previous one ended.
                 await self._record_live(puuid, game)
-                ended += 1
+                ended.append(puuid)
         if ended:
-            self.bot.logging.info(f"Live: {ended} game(s) just ended — refreshing the board now")
+            self.bot.logging.info(
+                f"Live: {len(ended)} game(s) just ended — refreshing the board now"
+            )
             board = self.bot.get_cog("FetchFromRiot")
             if board is not None:
+                # Announce the finishes directly — authoritative, and immune
+                # to the gate's diff state being reset by a sweep or reload.
+                board.note_finished(ended)
                 await board.post_ranks()
 
     @poll_live.error

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -1,0 +1,91 @@
+"""Live-game tracking: spectator-v5 polled for every tracked account.
+
+Every POLL_MINUTES the loop asks Riot whether each tracked player is in
+a game right now (one request per unique puuid through the shared
+riot_client budget — "not in game" is a quiet 404). Live games land in
+the live_games table (one row per game+player, raw payload included)
+and rows go stale-pruned once the game ends, so the table always
+mirrors "who is playing at this moment". The dashboard's /live page is
+the consumer; the bot itself posts nothing.
+"""
+
+import datetime as dt
+
+from discord.ext import commands, tasks
+from main import MyDiscordBot
+from psycopg.types.json import Jsonb
+from utils import db
+from utils.loop_restart import restart_loop_later
+from utils.riot_client import get_active_game
+
+POLL_MINUTES = 4
+
+# Rows older than two polls (plus slack) belong to finished games.
+STALE_MINUTES = POLL_MINUTES * 2 + 1
+
+
+class LiveGames(commands.Cog):
+    def __init__(self, bot: MyDiscordBot):
+        self.bot = bot
+        self.bot.logging.info(f"{__name__} loaded")
+        # Watchdog input, same contract as the other loops
+        # (cogs/heartbeat.py reloads us if this goes stale).
+        self.poll_live_last_fired: dt.datetime | None = None
+        self.poll_live.start()
+
+    def cog_unload(self) -> None:
+        # discord.py does NOT cancel @tasks.loop tasks on cog unload —
+        # without this, every hot reload leaves the old loop running.
+        self.poll_live.cancel()
+
+    @tasks.loop(minutes=POLL_MINUTES)
+    async def poll_live(self):
+        await self.bot.wait_until_ready()
+        rows = await db.fetchall(
+            "SELECT DISTINCT puuid FROM league_players WHERE puuid IS NOT NULL AND puuid != ''"
+        )
+        in_game = 0
+        for (puuid,) in rows:
+            game = await get_active_game(puuid)
+            if game is None:
+                continue
+            in_game += 1
+            start_ms = game.get("gameStartTime") or 0
+            # 0 during the loading screen — better no timestamp than 1970.
+            started = dt.datetime.fromtimestamp(start_ms / 1000, dt.UTC) if start_ms > 0 else None
+            await db.execute(
+                "INSERT INTO live_games (game_id, puuid, queue_id, game_start, payload, seen_at) "
+                "VALUES (%s, %s, %s, %s, %s, now()) "
+                "ON CONFLICT (game_id, puuid) DO UPDATE SET "
+                "payload = EXCLUDED.payload, seen_at = now()",
+                (
+                    game.get("gameId"),
+                    puuid,
+                    game.get("gameQueueConfigId"),
+                    started,
+                    Jsonb(game),
+                ),
+            )
+        await db.execute(
+            "DELETE FROM live_games WHERE seen_at < now() - make_interval(mins => %s)",
+            (STALE_MINUTES,),
+        )
+        if in_game:
+            self.bot.logging.info(f"Live games: {in_game} tracked account(s) in game")
+        self.poll_live_last_fired = dt.datetime.now()
+
+    @poll_live.error
+    async def poll_live_error(self, exc: BaseException) -> None:
+        """Auto-restart on unhandled error — default @tasks.loop behaviour
+        is log + stop, which would silently end live tracking."""
+        self.bot.logging.error(f"poll_live errored: {exc!r}, restarting in 60s")
+        restart_loop_later(
+            self.poll_live,
+            name="poll_live",
+            log=self.bot.logging,
+            still_active=lambda: self.bot.get_cog("LiveGames") is self,
+        )
+
+
+async def setup(bot: MyDiscordBot):
+    await bot.add_cog(LiveGames(bot))

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -82,29 +82,7 @@ class LiveGames(commands.Cog):
                 await db.execute("DELETE FROM live_games WHERE puuid = %s", (puuid,))
                 continue
             in_game += 1
-            start_ms = game.get("gameStartTime") or 0
-            # 0 during the loading screen — better no timestamp than 1970.
-            started = dt.datetime.fromtimestamp(start_ms / 1000, dt.UTC) if start_ms > 0 else None
-            await db.execute(
-                "INSERT INTO live_games (game_id, puuid, queue_id, game_start, payload, seen_at) "
-                "VALUES (%s, %s, %s, %s, %s, now()) "
-                "ON CONFLICT (game_id, puuid) DO UPDATE SET "
-                "payload = EXCLUDED.payload, seen_at = now()",
-                (
-                    game.get("gameId"),
-                    puuid,
-                    game.get("gameQueueConfigId"),
-                    started,
-                    Jsonb(game),
-                ),
-            )
-            # A player can only be in one game — drop any row from a
-            # previous game they've since left (finish A -> queue into B
-            # would otherwise show them in both until the prune).
-            await db.execute(
-                "DELETE FROM live_games WHERE puuid = %s AND game_id <> %s",
-                (puuid, game.get("gameId")),
-            )
+            await self._record_live(puuid, game)
         # Backstop for rows nothing refreshed or deleted (account removed
         # from tracking, persistent API failure, loop gaps).
         await db.execute(
@@ -115,6 +93,31 @@ class LiveGames(commands.Cog):
             self.bot.logging.info(f"Live games: {in_game} tracked account(s) in game")
         self.poll_live_last_fired = dt.datetime.now()
 
+    async def _record_live(self, puuid: str, game: dict) -> None:
+        """Upsert the player's current game and drop rows for any previous
+        game — a player can only be in one game, and finish-A-queue-into-B
+        must not show them in both."""
+        start_ms = game.get("gameStartTime") or 0
+        # 0 during the loading screen — better no timestamp than 1970.
+        started = dt.datetime.fromtimestamp(start_ms / 1000, dt.UTC) if start_ms > 0 else None
+        await db.execute(
+            "INSERT INTO live_games (game_id, puuid, queue_id, game_start, payload, seen_at) "
+            "VALUES (%s, %s, %s, %s, %s, now()) "
+            "ON CONFLICT (game_id, puuid) DO UPDATE SET "
+            "payload = EXCLUDED.payload, seen_at = now()",
+            (
+                game.get("gameId"),
+                puuid,
+                game.get("gameQueueConfigId"),
+                started,
+                Jsonb(game),
+            ),
+        )
+        await db.execute(
+            "DELETE FROM live_games WHERE puuid = %s AND game_id <> %s",
+            (puuid, game.get("gameId")),
+        )
+
     @tasks.loop(minutes=1)
     async def watch_endings(self):
         """Fast end-of-game detector: fresh LP on the board within ~a minute.
@@ -123,22 +126,34 @@ class LiveGames(commands.Cog):
         movement, so waiting for the 4-minute discovery poll + the next
         2-minute board cycle reads as "the board is stale". This loop
         only polls accounts CURRENTLY in live_games (zero Riot calls
-        when nobody is playing) and, the moment a game ends, deletes the
-        rows and triggers the board loop right away — its entries gating
-        sees the players vanish from live_games and fresh-fetches them.
+        when nobody is playing) and, the moment a game ends, updates the
+        table and triggers the board loop right away — its entries gating
+        sees the game vanish from live_games and fresh-fetches the players.
+
+        A game "ends" in two shapes: the player is no longer in any game
+        (spectator 404), OR they're already in a DIFFERENT game — the
+        finish-then-requeue case, where mere presence polling would never
+        show a gap. A changed gameId IS the end of the previous game.
         """
         await self.bot.wait_until_ready()
         try:
-            rows = await db.fetchall("SELECT DISTINCT puuid FROM live_games")
+            rows = await db.fetchall("SELECT puuid, game_id FROM live_games")
         except Exception:
             return  # table missing pre-restart; the main poll logs enough
+        known_games: dict[str, set[int]] = {}
+        for puuid, game_id in rows:
+            known_games.setdefault(puuid, set()).add(game_id)
         ended = 0
-        for (puuid,) in rows:
+        for puuid, game_ids in known_games.items():
             known, game = await get_active_game(puuid)
             if not known:
                 continue
             if game is None or not game.get("gameId"):
                 await db.execute("DELETE FROM live_games WHERE puuid = %s", (puuid,))
+                ended += 1
+            elif game.get("gameId") not in game_ids:
+                # Already in the NEXT game — the previous one ended.
+                await self._record_live(puuid, game)
                 ended += 1
         if ended:
             self.bot.logging.info(f"Live: {ended} game(s) just ended — refreshing the board now")

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -43,11 +43,13 @@ class LiveGames(commands.Cog):
         self.poll_live_last_fired: dt.datetime | None = None
         self._cycle = 0
         self.poll_live.start()
+        self.watch_endings.start()
 
     def cog_unload(self) -> None:
         # discord.py does NOT cancel @tasks.loop tasks on cog unload —
         # without this, every hot reload leaves the old loop running.
         self.poll_live.cancel()
+        self.watch_endings.cancel()
 
     @tasks.loop(minutes=POLL_MINUTES)
     async def poll_live(self):
@@ -113,6 +115,37 @@ class LiveGames(commands.Cog):
             self.bot.logging.info(f"Live games: {in_game} tracked account(s) in game")
         self.poll_live_last_fired = dt.datetime.now()
 
+    @tasks.loop(minutes=1)
+    async def watch_endings(self):
+        """Fast end-of-game detector: fresh LP on the board within ~a minute.
+
+        People finish a game and immediately check the board for the
+        movement, so waiting for the 4-minute discovery poll + the next
+        2-minute board cycle reads as "the board is stale". This loop
+        only polls accounts CURRENTLY in live_games (zero Riot calls
+        when nobody is playing) and, the moment a game ends, deletes the
+        rows and triggers the board loop right away — its entries gating
+        sees the players vanish from live_games and fresh-fetches them.
+        """
+        await self.bot.wait_until_ready()
+        try:
+            rows = await db.fetchall("SELECT DISTINCT puuid FROM live_games")
+        except Exception:
+            return  # table missing pre-restart; the main poll logs enough
+        ended = 0
+        for (puuid,) in rows:
+            known, game = await get_active_game(puuid)
+            if not known:
+                continue
+            if game is None or not game.get("gameId"):
+                await db.execute("DELETE FROM live_games WHERE puuid = %s", (puuid,))
+                ended += 1
+        if ended:
+            self.bot.logging.info(f"Live: {ended} game(s) just ended — refreshing the board now")
+            board = self.bot.get_cog("FetchFromRiot")
+            if board is not None:
+                await board.post_ranks()
+
     @poll_live.error
     async def poll_live_error(self, exc: BaseException) -> None:
         """Auto-restart on unhandled error — default @tasks.loop behaviour
@@ -121,6 +154,16 @@ class LiveGames(commands.Cog):
         restart_loop_later(
             self.poll_live,
             name="poll_live",
+            log=self.bot.logging,
+            still_active=lambda: self.bot.get_cog("LiveGames") is self,
+        )
+
+    @watch_endings.error
+    async def watch_endings_error(self, exc: BaseException) -> None:
+        self.bot.logging.error(f"watch_endings errored: {exc!r}, restarting in 60s")
+        restart_loop_later(
+            self.watch_endings,
+            name="watch_endings",
             log=self.bot.logging,
             still_active=lambda: self.bot.get_cog("LiveGames") is self,
         )

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -23,6 +23,16 @@ POLL_MINUTES = 4
 # Rows older than two polls (plus slack) belong to finished games.
 STALE_MINUTES = POLL_MINUTES * 2 + 1
 
+# Accounts with no recorded game in this many days only get polled every
+# DORMANT_EVERY_CYCLES cycles (~16 min): roughly half the roster is
+# dormant at any time, and spectator polls come out of the shared Riot
+# budget. Trade-off: a dormant player's FIRST live game can be seen up
+# to ~16 minutes late — after it finishes they're active again and back
+# on the fast cadence. Accounts currently in live_games always stay on
+# the fast cadence so an in-progress game keeps refreshing.
+DORMANT_AFTER_DAYS = 14
+DORMANT_EVERY_CYCLES = 4
+
 
 class LiveGames(commands.Cog):
     def __init__(self, bot: MyDiscordBot):
@@ -31,6 +41,7 @@ class LiveGames(commands.Cog):
         # Watchdog input, same contract as the other loops
         # (cogs/heartbeat.py reloads us if this goes stale).
         self.poll_live_last_fired: dt.datetime | None = None
+        self._cycle = 0
         self.poll_live.start()
 
     def cog_unload(self) -> None:
@@ -44,8 +55,20 @@ class LiveGames(commands.Cog):
         rows = await db.fetchall(
             "SELECT DISTINCT puuid FROM league_players WHERE puuid IS NOT NULL AND puuid != ''"
         )
+        self._cycle += 1
+        fast_cadence = {
+            r[0]
+            for r in await db.fetchall(
+                "SELECT DISTINCT puuid FROM match_stats "
+                "WHERE game_start > now() - make_interval(days => %s) "
+                "UNION SELECT puuid FROM live_games",
+                (DORMANT_AFTER_DAYS,),
+            )
+        }
         in_game = 0
         for (puuid,) in rows:
+            if puuid not in fast_cadence and self._cycle % DORMANT_EVERY_CYCLES:
+                continue
             known, game = await get_active_game(puuid)
             if not known:
                 # Transient API failure — leave existing rows alone; the

--- a/Bot/cogs/live_games.py
+++ b/Bot/cogs/live_games.py
@@ -46,8 +46,15 @@ class LiveGames(commands.Cog):
         )
         in_game = 0
         for (puuid,) in rows:
-            game = await get_active_game(puuid)
-            if game is None:
+            known, game = await get_active_game(puuid)
+            if not known:
+                # Transient API failure — leave existing rows alone; the
+                # staleness backstop below covers a persistent outage.
+                continue
+            if game is None or not game.get("gameId"):
+                # Authoritative "not in a game": remove immediately rather
+                # than letting a finished game linger until stale-pruned.
+                await db.execute("DELETE FROM live_games WHERE puuid = %s", (puuid,))
                 continue
             in_game += 1
             start_ms = game.get("gameStartTime") or 0
@@ -66,6 +73,15 @@ class LiveGames(commands.Cog):
                     Jsonb(game),
                 ),
             )
+            # A player can only be in one game — drop any row from a
+            # previous game they've since left (finish A -> queue into B
+            # would otherwise show them in both until the prune).
+            await db.execute(
+                "DELETE FROM live_games WHERE puuid = %s AND game_id <> %s",
+                (puuid, game.get("gameId")),
+            )
+        # Backstop for rows nothing refreshed or deleted (account removed
+        # from tracking, persistent API failure, loop gaps).
         await db.execute(
             "DELETE FROM live_games WHERE seen_at < now() - make_interval(mins => %s)",
             (STALE_MINUTES,),

--- a/Bot/db/setup.postgres.sql
+++ b/Bot/db/setup.postgres.sql
@@ -144,6 +144,21 @@ create table if not exists weekly_awards (
     unique (week_start, award, discord_user_id)
 );
 
+-- Live (spectator-v5) games for tracked players (cogs/live_games.py):
+-- one row per (game, tracked player), upserted each poll while the game
+-- runs and pruned by staleness once it ends. payload is the raw
+-- spectator response (participants, bans, clock) — the dashboard's
+-- /live page renders straight from it.
+create table if not exists live_games (
+    game_id BIGINT not null,
+    puuid TEXT not null,
+    queue_id INTEGER,
+    game_start TIMESTAMPTZ,
+    payload JSONB,
+    seen_at TIMESTAMPTZ not null default now(),
+    primary key (game_id, puuid)
+);
+
 -- Auto-detected season/split boundaries (utils/seasons.py): one row per
 -- ladder reset, derived from league_history games totals shrinking.
 -- started_at is the first post-reset snapshot observed — Riot's actual

--- a/Bot/utils/leaderboard.py
+++ b/Bot/utils/leaderboard.py
@@ -236,6 +236,7 @@ def render_board_entry(
     last_played: dt.datetime | None = None,
     *,
     apex_omits_games_word: bool = False,
+    live_suffix: str = "",
 ) -> str:
     """One board entry: name/arrow/flag line, rank line, played line,
     last-played line, last-5.
@@ -265,8 +266,8 @@ def render_board_entry(
         rank_line = f"Rank: {tier} {posting['rank']} {posting['leaguePoints']}lp"
     games_word = "" if is_apex and apex_omits_games_word else " games"
     return (
-        f"{position_arrow}{position}. {posting['summonerName']} - <@{posting['user_id']}>"
-        f"{updated_flag}\n"
+        f"{position_arrow}{position}. {posting['summonerName']}{live_suffix}"
+        f" - <@{posting['user_id']}>{updated_flag}\n"
         f"{rank_line}\n"
         f"Played: {posting['GamesPlayed']}{games_word} with a {posting['WinRate']:.2f}% winrate\n"
         f"{last_played_line(last_played)}"
@@ -281,6 +282,8 @@ async def render_board_entries(
     fetch_last_five,
     *,
     apex_omits_games_word: bool = False,
+    live_puuids: frozenset | set = frozenset(),
+    live_marker: str = "",
 ) -> tuple[list[str], dict[str, int], dict[str, int]]:
     """Render every entry of an already-sorted board.
 
@@ -323,6 +326,9 @@ async def render_board_entries(
                 last_five,
                 last_played,
                 apex_omits_games_word=apex_omits_games_word,
+                # In-game marker (e.g. a LIVE emoji) after the name only —
+                # positions/arrows key on summonerName, never the suffix.
+                live_suffix=live_marker if posting.get("puuid") in live_puuids else "",
             )
         )
     return output_list, previous_positions, current_positions

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -225,15 +225,21 @@ async def get_account_by_puuid(puuid: str) -> dict | None:
     return body
 
 
-async def get_active_game(puuid: str) -> dict | None:
-    """Spectator-v5 live game for a player, or None when not in one.
+async def get_active_game(puuid: str) -> tuple[bool, dict | None]:
+    """Spectator-v5 live game for a player: ``(known, game)``.
 
-    404 is the API's way of saying "not currently in a game" — the
-    overwhelmingly common answer — so it's handled quietly rather than
-    logged as an error. Platform host (euw1), like league entries.
+    ``(True, game)``  — in a game right now.
+    ``(True, None)``  — definitively NOT in a game (spectator 404, the
+                        overwhelmingly common answer, handled quietly).
+    ``(False, None)`` — transient failure; the caller must NOT treat it
+                        as "game over" or live rows flicker on API blips.
+
+    Platform host (euw1), like league entries.
     """
     url = f"{PLATFORM_HOST}/lol/spectator/v5/active-games/by-summoner/{puuid}"
     status, body = await _get_json(url, quiet_404=True)
-    if status != 200 or not isinstance(body, dict):
-        return None
-    return body
+    if status == 404:
+        return (True, None)
+    if status == 200 and isinstance(body, dict):
+        return (True, body)
+    return (False, None)

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -6,7 +6,8 @@ would silently exceed the limit when, say, the rank refresh loop and a
 /kda invocation collide. All Riot API requests in the codebase should go
 through the public functions in this module so the budget is shared.
 
-Limits (developer tier):
+Limits (confirmed 2026-08-05 from the X-App-Rate-Limit response header,
+owner-confirmed; registered key, no dev-key expiry):
   - 20 requests per 1 second
   - 100 requests per 2 minutes
 
@@ -59,6 +60,13 @@ RANKED_5S_QUEUE_ID = 710  # match-v5 queue for the weekend Ranked 5s queue
 # ~20 tracked players → no eviction needed.
 _ENTRIES_TTL_SECONDS = 130.0
 _entries_cache: dict[str, tuple[float, list[dict]]] = {}
+
+# How stale a cached entry may be served when the caller KNOWS it can't
+# have changed (allow_stale=True: player mid-game or idle — LP only
+# moves when a game ends). Capped so a bug in the caller's change
+# detection can never freeze the board for more than a couple of hours;
+# the solo board's hourly full sweep refreshes well before this.
+_ENTRIES_STALE_MAX_SECONDS = 2 * 3600.0
 
 log = logging.getLogger(__name__)
 
@@ -155,17 +163,25 @@ async def _get_json(
     return (429, None)
 
 
-async def get_league_entries(puuid: str, *, fresh: bool = False) -> list[dict] | None:
+async def get_league_entries(
+    puuid: str, *, fresh: bool = False, allow_stale: bool = False
+) -> list[dict] | None:
     """Ranked league entries for a player.
 
     Returns the list of league entries (one per ranked queue type the player
     has participated in), or ``None`` if the request failed. Responses are
     cached for ``_ENTRIES_TTL_SECONDS``; pass ``fresh=True`` to bypass.
+
+    ``allow_stale=True``: serve the cache up to ``_ENTRIES_STALE_MAX_SECONDS``
+    old — for callers that know the player's entries can't have changed
+    (mid-game or idle since the last fetch). Falls through to a real
+    fetch when nothing is cached.
     """
     cached = _entries_cache.get(puuid)
     if not fresh and cached is not None:
         age = time.monotonic() - cached[0]
-        if age < _ENTRIES_TTL_SECONDS:
+        max_age = _ENTRIES_STALE_MAX_SECONDS if allow_stale else _ENTRIES_TTL_SECONDS
+        if age < max_age:
             # Copy per hit: callers mutate the entry dicts in place
             # (board cogs inject Ranker/user_id keys), and a polluted
             # cache would alias one board's state into the other's.

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -95,13 +95,17 @@ async def _wait_for_slot() -> None:
         await asyncio.sleep(wait)
 
 
-async def _get_json(url: str, params: dict | None = None) -> tuple[int, list | dict | None]:
+async def _get_json(
+    url: str, params: dict | None = None, *, quiet_404: bool = False
+) -> tuple[int, list | dict | None]:
     """Rate-limited GET returning (status, parsed JSON or None).
 
     Internal — callers use the endpoint-specific wrappers below so they get
     typed return values instead of a bare ``list | dict``.
 
     On 429 honours ``Retry-After`` with small jitter and retries internally.
+    ``quiet_404``: for endpoints where 404 is an expected answer, not a
+    failure (spectator's "not in a game") — skips the error log.
     """
     riot_key = config.riot_api_key()
     if not riot_key:
@@ -116,6 +120,8 @@ async def _get_json(url: str, params: dict | None = None) -> tuple[int, list | d
                 async with session.get(url, params=params) as r:
                     if r.status == 200:
                         return (r.status, await r.json())
+                    if r.status == 404 and quiet_404:
+                        return (r.status, None)
                     if r.status == 429:
                         retry_after = int(r.headers.get("Retry-After", 10))
                         # Jitter so concurrent 429s don't retry in lockstep.
@@ -214,6 +220,20 @@ async def get_account_by_puuid(puuid: str) -> dict | None:
     """Account-v1 lookup by puuid (current gameName/tagLine). Regional host."""
     url = f"{REGION_HOST}/riot/account/v1/accounts/by-puuid/{puuid}"
     status, body = await _get_json(url)
+    if status != 200 or not isinstance(body, dict):
+        return None
+    return body
+
+
+async def get_active_game(puuid: str) -> dict | None:
+    """Spectator-v5 live game for a player, or None when not in one.
+
+    404 is the API's way of saying "not currently in a game" — the
+    overwhelmingly common answer — so it's handled quietly rather than
+    logged as an error. Platform host (euw1), like league entries.
+    """
+    url = f"{PLATFORM_HOST}/lol/spectator/v5/active-games/by-summoner/{puuid}"
+    status, body = await _get_json(url, quiet_404=True)
     if status != 200 or not isinstance(body, dict):
         return None
     return body

--- a/Bot/utils/riot_client.py
+++ b/Bot/utils/riot_client.py
@@ -51,10 +51,13 @@ RANKED_5S_QUEUE_ID = 710  # match-v5 queue for the weekend Ranked 5s queue
 # League entries are consumed by two board cogs (solo + ranked 5s) on
 # independent 120s loops. A response lists ALL of a player's ranked queues,
 # so a short TTL cache lets the second consumer reuse the first's response
-# instead of doubling API spend. TTL sits just below the loops' 120s period
-# so each cycle still gets fresh data while tolerating the loops drifting
-# out of phase. ~20 tracked players → no eviction needed.
-_ENTRIES_TTL_SECONDS = 115.0
+# instead of doubling API spend. TTL sits just ABOVE the loops' 120s
+# period so whichever board fetches first always serves the other from
+# cache — at 115s the loops drifting out of phase made both fetch, up to
+# doubling entries spend (~21 extra requests/2min). The second consumer
+# reads data at most one cycle old, which a board redraw can tolerate.
+# ~20 tracked players → no eviction needed.
+_ENTRIES_TTL_SECONDS = 130.0
 _entries_cache: dict[str, tuple[float, list[dict]]] = {}
 
 log = logging.getLogger(__name__)
@@ -82,6 +85,12 @@ async def _wait_for_slot() -> None:
 
             if wait <= 0:
                 _timestamps.append(now)
+                # Budget telemetry: one line as usage crosses each mark,
+                # so "are we pushing the rate limit?" is answerable from
+                # the logs instead of guessed at.
+                used = sum(1 for t in _timestamps if now - t <= 120)
+                if used in (70, 85, 95):
+                    log.info(f"Riot budget: {used}/100 requests in the current 2min window")
                 return
 
         # Release the lock while sleeping so other coroutines can re-check.

--- a/docs/riot-api-reference.md
+++ b/docs/riot-api-reference.md
@@ -15,17 +15,25 @@ Riot splits its API across two kinds of hosts, and picking the wrong one 404s:
 All Riot HTTP goes through `Bot/utils/riot_client.py` — do **not** add HTTP
 calls elsewhere. Reasons:
 
-- **Rate limits are per API key, shared across everything**: developer tier is
-  **20 requests / 1 s** and **100 requests / 120 s**. `riot_client` enforces
+- **Rate limits are per API key, shared across everything**: this key's
+  actual limits are **20 requests / 1 s** and **100 requests / 120 s** —
+  confirmed 2026-08-05 from Riot's own `X-App-Rate-Limit: 100:120,20:1`
+  response header (the authoritative source; re-check the same way after
+  any key change). The key is a registered/personal key (no 24 h expiry)
+  whose numbers happen to match the dev tier. `riot_client` enforces
   both windows with a single process-wide limiter (`_wait_for_slot`); a second
   limiter elsewhere would silently blow the budget. (This has bitten before —
-  a standalone backfill process starved the live loops.)
+  a standalone backfill process starved the live loops.) The limiter logs
+  a line as window usage crosses 70/85/95 of 100.
 - 429s are retried internally (honours `Retry-After` + jitter, up to
   `MAX_RETRIES = 2`).
-- **Entries TTL cache**: `get_league_entries` caches responses for **100 s**
-  per puuid. One league-v4 response lists *all* of a player's ranked queues,
-  so the solo board and the Ranked 5s board (both on 120 s loops) share one
-  fetch per player per cycle. Pass `fresh=True` to bypass.
+- **Entries TTL cache**: `get_league_entries` caches responses for **130 s**
+  per puuid — just above the boards' 120 s loop period, so whichever board
+  fetches first serves the other from cache. One league-v4 response lists
+  *all* of a player's ranked queues. Pass `fresh=True` to bypass, or
+  `allow_stale=True` to accept up to 2 h old data when the caller knows the
+  entries can't have changed (player mid-game or idle — LP only moves when
+  a game ends; the solo board uses this with an hourly full sweep).
 
 The API key comes from the `riot_key` env var.
 


### PR DESCRIPTION
Bot half of the dashboard's new **Live** page.

## What
- `cogs/live_games.py`: 4-minute loop asking spectator-v5 whether each tracked account is in a game (one request per unique puuid via the shared `riot_client` budget — ~21 requests/cycle against the 100/2min cap, alongside the cached entries + stream loops).
- Live games land in a new `live_games` table (one row per game+player, raw spectator payload incl. both teams/bans/clock); rows stale-prune two polls after the game ends. The dashboard renders `/live` straight from it.
- `riot_client.get_active_game` with `quiet_404`: spectator answers 404 for "not in a game" constantly — that must not hit the error log.
- Loop hygiene per house pattern: `cog_unload` cancel, `restart_loop_later` on error, heartbeat watchdog entry (12 min threshold).

## Deploy
New table → schema applies at boot → needs the container restart that's already owed for #71/#72's boot hooks. One restart covers everything.